### PR TITLE
chore: Enable modernize-avoid-bind

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -64,7 +64,6 @@ Checks: "-*,
   -misc-use-internal-linkage,
 
   modernize-*,
-  -modernize-avoid-bind,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
   -modernize-avoid-setjmp-longjmp,

--- a/include/xrpl/basics/TaggedCache.ipp
+++ b/include/xrpl/basics/TaggedCache.ipp
@@ -57,7 +57,10 @@ inline TaggedCache<
         beast::insight::Collector::ptr const& collector)
     : journal_(journal)
     , clock_(clock)
-    , stats_(name, std::bind(&TaggedCache::collectMetrics, this), collector)
+    , stats_(
+          name,
+          [this] { collectMetrics(); },
+          collector)
     , name_(name)
     , targetSize_(size)
     , targetAge_(expiration)

--- a/include/xrpl/beast/unit_test/thread.h
+++ b/include/xrpl/beast/unit_test/thread.h
@@ -45,7 +45,10 @@ public:
     template <class F, class... Args>
     explicit Thread(Suite& s, F&& f, Args&&... args) : s_(&s)
     {
-        std::function<void(void)> b = std::bind(std::forward<F>(f), std::forward<Args>(args)...);
+        std::function<void(void)> b = [Func = std::forward<F>(f),
+                                       capture0 = std::forward<Args>(args)] {
+            Func(capture0, capture1);
+        };
         t_ = std::thread(&Thread::run, this, std::move(b));
     }
 

--- a/include/xrpl/beast/unit_test/thread.h
+++ b/include/xrpl/beast/unit_test/thread.h
@@ -47,7 +47,7 @@ public:
     {
         std::function<void(void)> b = [Func = std::forward<F>(f),
                                        capture0 = std::forward<Args>(args)] {
-            Func(capture0, capture1);
+            Func(capture0, capture0);
         };
         t_ = std::thread(&Thread::run, this, std::move(b));
     }

--- a/include/xrpl/beast/unit_test/thread.h
+++ b/include/xrpl/beast/unit_test/thread.h
@@ -45,10 +45,8 @@ public:
     template <class F, class... Args>
     explicit Thread(Suite& s, F&& f, Args&&... args) : s_(&s)
     {
-        std::function<void(void)> b = [Func = std::forward<F>(f),
-                                       capture0 = std::forward<Args>(args)] {
-            Func(capture0, capture0);
-        };
+        std::function<void(void)> b =
+            [f = std::forward<F>(f), ... args = std::forward<Args>(args)]() mutable { f(args...); };
         t_ = std::thread(&Thread::run, this, std::move(b));
     }
 

--- a/include/xrpl/beast/unit_test/thread.h
+++ b/include/xrpl/beast/unit_test/thread.h
@@ -45,8 +45,10 @@ public:
     template <class F, class... Args>
     explicit Thread(Suite& s, F&& f, Args&&... args) : s_(&s)
     {
-        std::function<void(void)> b =
-            [f = std::forward<F>(f), ... args = std::forward<Args>(args)]() mutable { f(args...); };
+        std::function<void(void)> b = [f = std::forward<F>(f),
+                                       ... args = std::forward<Args>(args)]() mutable {
+            std::invoke(f, args...);
+        };
         t_ = std::thread(&Thread::run, this, std::move(b));
     }
 

--- a/include/xrpl/net/AutoSocket.h
+++ b/include/xrpl/net/AutoSocket.h
@@ -120,12 +120,10 @@ public:
             socket_->next_layer().async_receive(
                 boost::asio::buffer(buffer_),
                 boost::asio::socket_base::message_peek,
-                std::bind(
-                    &AutoSocket::handleAutodetect,
-                    this,
-                    cbFunc,
-                    std::placeholders::_1,
-                    std::placeholders::_2));
+                [this, cbFunc](auto&& PH1, auto&& PH2) {
+                    handleAutodetect(
+                        cbFunc, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                });
         }
     }
 

--- a/include/xrpl/net/AutoSocket.h
+++ b/include/xrpl/net/AutoSocket.h
@@ -120,9 +120,9 @@ public:
             socket_->next_layer().async_receive(
                 boost::asio::buffer(buffer_),
                 boost::asio::socket_base::message_peek,
-                [this, cbFunc](auto&& PH1, auto&& PH2) {
+                [this, cbFunc](auto&& pH1, auto&& pH2) {
                     handleAutodetect(
-                        cbFunc, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                        cbFunc, std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                 });
         }
     }

--- a/include/xrpl/net/AutoSocket.h
+++ b/include/xrpl/net/AutoSocket.h
@@ -120,9 +120,8 @@ public:
             socket_->next_layer().async_receive(
                 boost::asio::buffer(buffer_),
                 boost::asio::socket_base::message_peek,
-                [this, cbFunc](auto&& pH1, auto&& pH2) {
-                    handleAutodetect(
-                        cbFunc, std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+                [this, cbFunc](error_code const& ec, size_t bytesTransferred) {
+                    handleAutodetect(cbFunc, ec, bytesTransferred);
                 });
         }
     }

--- a/include/xrpl/net/HTTPClientSSLContext.h
+++ b/include/xrpl/net/HTTPClientSSLContext.h
@@ -126,8 +126,8 @@ public:
             if (!ec)
             {
                 strm.set_verify_callback(
-                    [host, this](bool preverified, boost::asio::ssl::verify_context& ctx) {
-                        return rfc6125Verify(host, preverified, ctx, j_);
+                    [host, j = j_](bool preverified, boost::asio::ssl::verify_context& ctx) {
+                        return rfc6125Verify(host, preverified, ctx, j);
                     },
                     ec);
             }

--- a/include/xrpl/net/HTTPClientSSLContext.h
+++ b/include/xrpl/net/HTTPClientSSLContext.h
@@ -126,12 +126,8 @@ public:
             if (!ec)
             {
                 strm.set_verify_callback(
-                    [host, this](auto&& pH1, auto&& pH2) {
-                        return rfc6125Verify(
-                            host,
-                            std::forward<decltype(pH1)>(pH1),
-                            std::forward<decltype(pH2)>(pH2),
-                            j_);
+                    [host, this](bool preverified, boost::asio::ssl::verify_context& ctx) {
+                        return rfc6125Verify(host, preverified, ctx, j_);
                     },
                     ec);
             }

--- a/include/xrpl/net/HTTPClientSSLContext.h
+++ b/include/xrpl/net/HTTPClientSSLContext.h
@@ -13,7 +13,6 @@
 #include <openssl/err.h>
 #include <openssl/tls1.h>
 
-#include <functional>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -127,11 +126,11 @@ public:
             if (!ec)
             {
                 strm.set_verify_callback(
-                    [host, this](auto&& PH1, auto&& PH2) {
+                    [host, this](auto&& pH1, auto&& pH2) {
                         return rfc6125Verify(
                             host,
-                            std::forward<decltype(PH1)>(PH1),
-                            std::forward<decltype(PH2)>(PH2),
+                            std::forward<decltype(pH1)>(pH1),
+                            std::forward<decltype(pH2)>(pH2),
                             j_);
                     },
                     ec);

--- a/include/xrpl/net/HTTPClientSSLContext.h
+++ b/include/xrpl/net/HTTPClientSSLContext.h
@@ -127,8 +127,13 @@ public:
             if (!ec)
             {
                 strm.set_verify_callback(
-                    std::bind(
-                        &rfc6125Verify, host, std::placeholders::_1, std::placeholders::_2, j_),
+                    [host, this](auto&& PH1, auto&& PH2) {
+                        return rfc6125Verify(
+                            host,
+                            std::forward<decltype(PH1)>(PH1),
+                            std::forward<decltype(PH2)>(PH2),
+                            j_);
+                    },
                     ec);
             }
         }

--- a/include/xrpl/server/detail/BaseHTTPPeer.h
+++ b/include/xrpl/server/detail/BaseHTTPPeer.h
@@ -223,10 +223,7 @@ BaseHTTPPeer<Handler, Impl>::close()
 {
     if (!strand_.running_in_this_thread())
     {
-        return post(
-            strand_,
-            std::bind(
-                (void (BaseHTTPPeer::*)(void))&BaseHTTPPeer::close, impl().shared_from_this()));
+        return post(strand_, [self = impl().shared_from_this()] { self->close(); });
     }
     boost::beast::get_lowest_layer(impl().stream_).close();
 }
@@ -320,17 +317,19 @@ BaseHTTPPeer<Handler, Impl>::onWrite(error_code const& ec, std::size_t bytesTran
         return boost::asio::async_write(
             impl().stream_,
             v,
-            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1, auto&& pH2) {
-                capture0->onWrite(
-                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-            }));
+            bind_executor(
+                strand_,
+                [self = impl().shared_from_this()](
+                    error_code const& ec, std::size_t bytesTransferred) {
+                    self->onWrite(ec, bytesTransferred);
+                }));
     }
     if (!complete_)
         return;
     if (graceful_)
         return doClose();
-    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-        capture0->doRead(std::forward<decltype(pH1)>(pH1));
+    util::spawn(strand_, [self = impl().shared_from_this()](yield_context doYield) {
+        self->doRead(doYield);
     });
 }
 
@@ -345,8 +344,8 @@ BaseHTTPPeer<Handler, Impl>::doWriter(
     {
         auto const p = impl().shared_from_this();
         resume = std::function<void(void)>([this, p, writer, keepAlive]() {
-            util::spawn(strand_, [p, writer, keepAlive](auto&& pH1) {
-                p->doWriter(writer, keepAlive, std::forward<decltype(pH1)>(pH1));
+            util::spawn(strand_, [p, writer, keepAlive](yield_context doYield) {
+                p->doWriter(writer, keepAlive, doYield);
             });
         });
     }
@@ -368,8 +367,8 @@ BaseHTTPPeer<Handler, Impl>::doWriter(
     if (!keepAlive)
         return doClose();
 
-    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-        capture0->doRead(std::forward<decltype(pH1)>(pH1));
+    util::spawn(strand_, [self = impl().shared_from_this()](yield_context doYield) {
+        self->doRead(doYield);
     });
 }
 
@@ -390,9 +389,8 @@ BaseHTTPPeer<Handler, Impl>::write(void const* buf, std::size_t bytes)
     {
         if (!strand_.running_in_this_thread())
         {
-            return post(strand_, [capture0 = impl().shared_from_this()] {
-                capture0->onWrite(error_code{}, 0);
-            });
+            return post(
+                strand_, [self = impl().shared_from_this()] { self->onWrite(error_code{}, 0); });
         }
         return onWrite(error_code{}, 0);
     }
@@ -402,9 +400,10 @@ template <class Handler, class Impl>
 void
 BaseHTTPPeer<Handler, Impl>::write(std::shared_ptr<Writer> const& writer, bool keepAlive)
 {
-    util::spawn(strand_, [capture0 = impl().shared_from_this(), writer, keepAlive](auto&& pH1) {
-        capture0->doWriter(writer, keepAlive, std::forward<decltype(pH1)>(pH1));
-    });
+    util::spawn(
+        strand_, [self = impl().shared_from_this(), writer, keepAlive](yield_context doYield) {
+            self->doWriter(writer, keepAlive, doYield);
+        });
 }
 
 // DEPRECATED
@@ -424,7 +423,7 @@ BaseHTTPPeer<Handler, Impl>::complete()
 {
     if (!strand_.running_in_this_thread())
     {
-        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->complete(); });
+        return post(strand_, [self = impl().shared_from_this()] { self->complete(); });
     }
 
     message_ = {};
@@ -437,8 +436,8 @@ BaseHTTPPeer<Handler, Impl>::complete()
     }
 
     // keep-alive
-    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-        capture0->doRead(std::forward<decltype(pH1)>(pH1));
+    util::spawn(strand_, [self = impl().shared_from_this()](yield_context doYield) {
+        self->doRead(doYield);
     });
 }
 
@@ -451,11 +450,7 @@ BaseHTTPPeer<Handler, Impl>::close(bool graceful)
     if (!strand_.running_in_this_thread())
     {
         return post(
-            strand_,
-            std::bind(
-                (void (BaseHTTPPeer::*)(bool))&BaseHTTPPeer<Handler, Impl>::close,
-                impl().shared_from_this(),
-                graceful));
+            strand_, [self = impl().shared_from_this(), graceful] { self->close(graceful); });
     }
 
     complete_ = true;

--- a/include/xrpl/server/detail/BaseHTTPPeer.h
+++ b/include/xrpl/server/detail/BaseHTTPPeer.h
@@ -320,24 +320,18 @@ BaseHTTPPeer<Handler, Impl>::onWrite(error_code const& ec, std::size_t bytesTran
         return boost::asio::async_write(
             impl().stream_,
             v,
-            bind_executor(
-                strand_,
-                std::bind(
-                    &BaseHTTPPeer::onWrite,
-                    impl().shared_from_this(),
-                    std::placeholders::_1,
-                    std::placeholders::_2)));
+            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1, auto&& PH2) {
+                capture0->onWrite(
+                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            }));
     }
     if (!complete_)
         return;
     if (graceful_)
         return doClose();
-    util::spawn(
-        strand_,
-        std::bind(
-            &BaseHTTPPeer<Handler, Impl>::doRead,
-            impl().shared_from_this(),
-            std::placeholders::_1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 template <class Handler, class Impl>
@@ -351,14 +345,9 @@ BaseHTTPPeer<Handler, Impl>::doWriter(
     {
         auto const p = impl().shared_from_this();
         resume = std::function<void(void)>([this, p, writer, keepAlive]() {
-            util::spawn(
-                strand_,
-                std::bind(
-                    &BaseHTTPPeer<Handler, Impl>::doWriter,
-                    p,
-                    writer,
-                    keepAlive,
-                    std::placeholders::_1));
+            util::spawn(strand_, [p, writer, keepAlive](auto&& PH1) {
+                p->doWriter(writer, keepAlive, std::forward<decltype(PH1)>(PH1));
+            });
         });
     }
 
@@ -379,12 +368,9 @@ BaseHTTPPeer<Handler, Impl>::doWriter(
     if (!keepAlive)
         return doClose();
 
-    util::spawn(
-        strand_,
-        std::bind(
-            &BaseHTTPPeer<Handler, Impl>::doRead,
-            impl().shared_from_this(),
-            std::placeholders::_1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 //------------------------------------------------------------------------------
@@ -404,9 +390,9 @@ BaseHTTPPeer<Handler, Impl>::write(void const* buf, std::size_t bytes)
     {
         if (!strand_.running_in_this_thread())
         {
-            return post(
-                strand_,
-                std::bind(&BaseHTTPPeer::onWrite, impl().shared_from_this(), error_code{}, 0));
+            return post(strand_, [capture0 = impl().shared_from_this()] {
+                capture0->onWrite(error_code{}, 0);
+            });
         }
         return onWrite(error_code{}, 0);
     }
@@ -416,14 +402,9 @@ template <class Handler, class Impl>
 void
 BaseHTTPPeer<Handler, Impl>::write(std::shared_ptr<Writer> const& writer, bool keepAlive)
 {
-    util::spawn(
-        strand_,
-        std::bind(
-            &BaseHTTPPeer<Handler, Impl>::doWriter,
-            impl().shared_from_this(),
-            writer,
-            keepAlive,
-            std::placeholders::_1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this(), writer, keepAlive](auto&& PH1) {
+        capture0->doWriter(writer, keepAlive, std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 // DEPRECATED
@@ -443,8 +424,7 @@ BaseHTTPPeer<Handler, Impl>::complete()
 {
     if (!strand_.running_in_this_thread())
     {
-        return post(
-            strand_, std::bind(&BaseHTTPPeer<Handler, Impl>::complete, impl().shared_from_this()));
+        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->complete(); });
     }
 
     message_ = {};
@@ -457,12 +437,9 @@ BaseHTTPPeer<Handler, Impl>::complete()
     }
 
     // keep-alive
-    util::spawn(
-        strand_,
-        std::bind(
-            &BaseHTTPPeer<Handler, Impl>::doRead,
-            impl().shared_from_this(),
-            std::placeholders::_1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 // DEPRECATED

--- a/include/xrpl/server/detail/BaseHTTPPeer.h
+++ b/include/xrpl/server/detail/BaseHTTPPeer.h
@@ -320,17 +320,17 @@ BaseHTTPPeer<Handler, Impl>::onWrite(error_code const& ec, std::size_t bytesTran
         return boost::asio::async_write(
             impl().stream_,
             v,
-            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1, auto&& PH2) {
+            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1, auto&& pH2) {
                 capture0->onWrite(
-                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             }));
     }
     if (!complete_)
         return;
     if (graceful_)
         return doClose();
-    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+        capture0->doRead(std::forward<decltype(pH1)>(pH1));
     });
 }
 
@@ -345,8 +345,8 @@ BaseHTTPPeer<Handler, Impl>::doWriter(
     {
         auto const p = impl().shared_from_this();
         resume = std::function<void(void)>([this, p, writer, keepAlive]() {
-            util::spawn(strand_, [p, writer, keepAlive](auto&& PH1) {
-                p->doWriter(writer, keepAlive, std::forward<decltype(PH1)>(PH1));
+            util::spawn(strand_, [p, writer, keepAlive](auto&& pH1) {
+                p->doWriter(writer, keepAlive, std::forward<decltype(pH1)>(pH1));
             });
         });
     }
@@ -368,8 +368,8 @@ BaseHTTPPeer<Handler, Impl>::doWriter(
     if (!keepAlive)
         return doClose();
 
-    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+        capture0->doRead(std::forward<decltype(pH1)>(pH1));
     });
 }
 
@@ -402,8 +402,8 @@ template <class Handler, class Impl>
 void
 BaseHTTPPeer<Handler, Impl>::write(std::shared_ptr<Writer> const& writer, bool keepAlive)
 {
-    util::spawn(strand_, [capture0 = impl().shared_from_this(), writer, keepAlive](auto&& PH1) {
-        capture0->doWriter(writer, keepAlive, std::forward<decltype(PH1)>(PH1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this(), writer, keepAlive](auto&& pH1) {
+        capture0->doWriter(writer, keepAlive, std::forward<decltype(pH1)>(pH1));
     });
 }
 
@@ -437,8 +437,8 @@ BaseHTTPPeer<Handler, Impl>::complete()
     }
 
     // keep-alive
-    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    util::spawn(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+        capture0->doRead(std::forward<decltype(pH1)>(pH1));
     });
 }
 

--- a/include/xrpl/server/detail/BasePeer.h
+++ b/include/xrpl/server/detail/BasePeer.h
@@ -83,7 +83,7 @@ void
 BasePeer<Handler, Impl>::close()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->close(); });
+        return post(strand_, [self = impl().shared_from_this()] { self->close(); });
     error_code ec;
     xrpl::getLowestLayer(impl().ws_).socket().close(ec);
 }

--- a/include/xrpl/server/detail/BasePeer.h
+++ b/include/xrpl/server/detail/BasePeer.h
@@ -10,7 +10,6 @@
 
 #include <atomic>
 #include <chrono>
-#include <functional>
 #include <string>
 #include <utility>
 

--- a/include/xrpl/server/detail/BasePeer.h
+++ b/include/xrpl/server/detail/BasePeer.h
@@ -84,7 +84,7 @@ void
 BasePeer<Handler, Impl>::close()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, std::bind(&BasePeer::close, impl().shared_from_this()));
+        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->close(); });
     error_code ec;
     xrpl::getLowestLayer(impl().ws_).socket().close(ec);
 }

--- a/include/xrpl/server/detail/BaseWSPeer.h
+++ b/include/xrpl/server/detail/BaseWSPeer.h
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstddef>
 #include <functional>
 #include <iterator>
 #include <list>

--- a/include/xrpl/server/detail/BaseWSPeer.h
+++ b/include/xrpl/server/detail/BaseWSPeer.h
@@ -180,12 +180,13 @@ void
 BaseWSPeer<Handler, Impl>::run()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, std::bind(&BaseWSPeer::run, impl().shared_from_this()));
+        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->run(); });
     impl().ws_.set_option(port().pmdOptions);
     // Must manage the control callback memory outside of the `control_callback`
     // function
-    controlCallback_ =
-        std::bind(&BaseWSPeer::onPingPong, this, std::placeholders::_1, std::placeholders::_2);
+    controlCallback_ = [this](auto&& PH1, auto&& PH2) {
+        onPingPong(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+    };
     impl().ws_.control_callback(controlCallback_);
     startTimer();
     closeOnTimer_ = true;
@@ -193,11 +194,9 @@ BaseWSPeer<Handler, Impl>::run()
         res.set(boost::beast::http::field::server, BuildInfo::getFullVersionString());
     }));
     impl().ws_.async_accept(
-        request_,
-        bind_executor(
-            strand_,
-            std::bind(
-                &BaseWSPeer::onWsHandshake, impl().shared_from_this(), std::placeholders::_1)));
+        request_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+            capture0->onWsHandshake(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 template <class Handler, class Impl>
@@ -205,7 +204,9 @@ void
 BaseWSPeer<Handler, Impl>::send(std::shared_ptr<WSMsg> w)
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, std::bind(&BaseWSPeer::send, impl().shared_from_this(), std::move(w)));
+        return post(strand_, [capture0 = impl().shared_from_this(), capture1 = std::move(w)] {
+            capture0->send(capture1);
+        });
     if (doClose_)
         return;
     if (wq_.size() > port().wsQueueLimit)
@@ -258,7 +259,7 @@ void
 BaseWSPeer<Handler, Impl>::complete()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, std::bind(&BaseWSPeer::complete, impl().shared_from_this()));
+        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->complete(); });
     doRead();
 }
 
@@ -277,7 +278,7 @@ void
 BaseWSPeer<Handler, Impl>::doWrite()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, std::bind(&BaseWSPeer::doWrite, impl().shared_from_this()));
+        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->doWrite(); });
     onWrite({});
 }
 
@@ -289,7 +290,7 @@ BaseWSPeer<Handler, Impl>::onWrite(error_code const& ec)
         return fail(ec, "write");
     auto& w = *wq_.front();
     auto const result =
-        w.prepare(65536, std::bind(&BaseWSPeer::doWrite, impl().shared_from_this()));
+        w.prepare(65536, [capture0 = impl().shared_from_this()] { capture0->doWrite(); });
     if (boost::indeterminate(result.first))
         return;
     startTimer();
@@ -298,19 +299,18 @@ BaseWSPeer<Handler, Impl>::onWrite(error_code const& ec)
         impl().ws_.async_write_some(
             static_cast<bool>(result.first),
             result.second,
-            bind_executor(
-                strand_,
-                std::bind(&BaseWSPeer::onWrite, impl().shared_from_this(), std::placeholders::_1)));
+            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+                capture0->onWrite(std::forward<decltype(PH1)>(PH1));
+            }));
     }
     else
     {
         impl().ws_.async_write_some(
             static_cast<bool>(result.first),
             result.second,
-            bind_executor(
-                strand_,
-                std::bind(
-                    &BaseWSPeer::onWriteFin, impl().shared_from_this(), std::placeholders::_1)));
+            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+                capture0->onWriteFin(std::forward<decltype(PH1)>(PH1));
+            }));
     }
 }
 
@@ -324,10 +324,9 @@ BaseWSPeer<Handler, Impl>::onWriteFin(error_code const& ec)
     if (doClose_)
     {
         impl().ws_.async_close(
-            cr_,
-            bind_executor(
-                strand_,
-                std::bind(&BaseWSPeer::onClose, impl().shared_from_this(), std::placeholders::_1)));
+            cr_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+                capture0->onClose(std::forward<decltype(PH1)>(PH1));
+            }));
     }
     else if (!wq_.empty())
     {
@@ -340,12 +339,11 @@ void
 BaseWSPeer<Handler, Impl>::doRead()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, std::bind(&BaseWSPeer::doRead, impl().shared_from_this()));
+        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->doRead(); });
     impl().ws_.async_read(
-        rb_,
-        bind_executor(
-            strand_,
-            std::bind(&BaseWSPeer::onRead, impl().shared_from_this(), std::placeholders::_1)));
+        rb_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+            capture0->onRead(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 template <class Handler, class Impl>
@@ -388,12 +386,9 @@ BaseWSPeer<Handler, Impl>::startTimer()
         return fail(e.code(), "start_timer");
     }
 
-    timer_.async_wait(bind_executor(
-        strand_,
-        std::bind(
-            &BaseWSPeer<Handler, Impl>::onTimer,
-            impl().shared_from_this(),
-            std::placeholders::_1)));
+    timer_.async_wait(bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+        capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+    }));
 }
 
 // Convenience for discarding the error code
@@ -461,10 +456,9 @@ BaseWSPeer<Handler, Impl>::onTimer(error_code ec)
             beast::rngfill(payload_.begin(), payload_.size(), cryptoPrng());
             impl().ws_.async_ping(
                 payload_,
-                bind_executor(
-                    strand_,
-                    std::bind(
-                        &BaseWSPeer::onPing, impl().shared_from_this(), std::placeholders::_1)));
+                bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+                    capture0->onPing(std::forward<decltype(PH1)>(PH1));
+                }));
             JLOG(this->j_.trace()) << "sent ping";
             return;
         }

--- a/include/xrpl/server/detail/BaseWSPeer.h
+++ b/include/xrpl/server/detail/BaseWSPeer.h
@@ -180,13 +180,13 @@ void
 BaseWSPeer<Handler, Impl>::run()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->run(); });
+        return post(strand_, [self = impl().shared_from_this()] { self->run(); });
     impl().ws_.set_option(port().pmdOptions);
     // Must manage the control callback memory outside of the `control_callback`
     // function
-    controlCallback_ = [this](auto&& pH1, auto&& pH2) {
-        onPingPong(std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-    };
+    controlCallback_ = [this](
+                           boost::beast::websocket::frame_type kind,
+                           boost::beast::string_view payload) { onPingPong(kind, payload); };
     impl().ws_.control_callback(controlCallback_);
     startTimer();
     closeOnTimer_ = true;
@@ -194,8 +194,8 @@ BaseWSPeer<Handler, Impl>::run()
         res.set(boost::beast::http::field::server, BuildInfo::getFullVersionString());
     }));
     impl().ws_.async_accept(
-        request_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-            capture0->onWsHandshake(std::forward<decltype(pH1)>(pH1));
+        request_, bind_executor(strand_, [self = impl().shared_from_this()](error_code const& ec) {
+            self->onWsHandshake(ec);
         }));
 }
 
@@ -205,11 +205,8 @@ BaseWSPeer<Handler, Impl>::send(std::shared_ptr<WSMsg> w)
 {
     if (!strand_.running_in_this_thread())
     {
-        {
-            return post(strand_, [capture0 = impl().shared_from_this(), capture1 = std::move(w)] {
-                capture0->send(capture1);
-            });
-        }
+        return post(
+            strand_, [self = impl().shared_from_this(), w = std::move(w)] { self->send(w); });
     }
     if (doClose_)
         return;
@@ -263,7 +260,7 @@ void
 BaseWSPeer<Handler, Impl>::complete()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->complete(); });
+        return post(strand_, [self = impl().shared_from_this()] { self->complete(); });
     doRead();
 }
 
@@ -282,7 +279,7 @@ void
 BaseWSPeer<Handler, Impl>::doWrite()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->doWrite(); });
+        return post(strand_, [self = impl().shared_from_this()] { self->doWrite(); });
     onWrite({});
 }
 
@@ -293,8 +290,7 @@ BaseWSPeer<Handler, Impl>::onWrite(error_code const& ec)
     if (ec)
         return fail(ec, "write");
     auto& w = *wq_.front();
-    auto const result =
-        w.prepare(65536, [capture0 = impl().shared_from_this()] { capture0->doWrite(); });
+    auto const result = w.prepare(65536, [self = impl().shared_from_this()] { self->doWrite(); });
     if (boost::indeterminate(result.first))
         return;
     startTimer();
@@ -303,18 +299,20 @@ BaseWSPeer<Handler, Impl>::onWrite(error_code const& ec)
         impl().ws_.async_write_some(
             static_cast<bool>(result.first),
             result.second,
-            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-                capture0->onWrite(std::forward<decltype(pH1)>(pH1));
-            }));
+            bind_executor(
+                strand_, [self = impl().shared_from_this()](error_code const& ec, std::size_t) {
+                    self->onWrite(ec);
+                }));
     }
     else
     {
         impl().ws_.async_write_some(
             static_cast<bool>(result.first),
             result.second,
-            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-                capture0->onWriteFin(std::forward<decltype(pH1)>(pH1));
-            }));
+            bind_executor(
+                strand_, [self = impl().shared_from_this()](error_code const& ec, std::size_t) {
+                    self->onWriteFin(ec);
+                }));
     }
 }
 
@@ -328,8 +326,8 @@ BaseWSPeer<Handler, Impl>::onWriteFin(error_code const& ec)
     if (doClose_)
     {
         impl().ws_.async_close(
-            cr_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-                capture0->onClose(std::forward<decltype(pH1)>(pH1));
+            cr_, bind_executor(strand_, [self = impl().shared_from_this()](error_code const& ec) {
+                self->onClose(ec);
             }));
     }
     else if (!wq_.empty())
@@ -343,11 +341,13 @@ void
 BaseWSPeer<Handler, Impl>::doRead()
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, [capture0 = impl().shared_from_this()] { capture0->doRead(); });
+        return post(strand_, [self = impl().shared_from_this()] { self->doRead(); });
     impl().ws_.async_read(
-        rb_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-            capture0->onRead(std::forward<decltype(pH1)>(pH1));
-        }));
+        rb_,
+        bind_executor(
+            strand_, [self = impl().shared_from_this()](error_code const& ec, std::size_t) {
+                self->onRead(ec);
+            }));
 }
 
 template <class Handler, class Impl>
@@ -390,9 +390,8 @@ BaseWSPeer<Handler, Impl>::startTimer()
         return fail(e.code(), "start_timer");
     }
 
-    timer_.async_wait(bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-        capture0->onTimer(std::forward<decltype(pH1)>(pH1));
-    }));
+    timer_.async_wait(bind_executor(
+        strand_, [self = impl().shared_from_this()](error_code const& ec) { self->onTimer(ec); }));
 }
 
 // Convenience for discarding the error code
@@ -460,8 +459,8 @@ BaseWSPeer<Handler, Impl>::onTimer(error_code ec)
             beast::rngfill(payload_.begin(), payload_.size(), cryptoPrng());
             impl().ws_.async_ping(
                 payload_,
-                bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-                    capture0->onPing(std::forward<decltype(pH1)>(pH1));
+                bind_executor(strand_, [self = impl().shared_from_this()](error_code const& ec) {
+                    self->onPing(ec);
                 }));
             JLOG(this->j_.trace()) << "sent ping";
             return;

--- a/include/xrpl/server/detail/BaseWSPeer.h
+++ b/include/xrpl/server/detail/BaseWSPeer.h
@@ -184,8 +184,8 @@ BaseWSPeer<Handler, Impl>::run()
     impl().ws_.set_option(port().pmdOptions);
     // Must manage the control callback memory outside of the `control_callback`
     // function
-    controlCallback_ = [this](auto&& PH1, auto&& PH2) {
-        onPingPong(std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+    controlCallback_ = [this](auto&& pH1, auto&& pH2) {
+        onPingPong(std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
     };
     impl().ws_.control_callback(controlCallback_);
     startTimer();
@@ -194,8 +194,8 @@ BaseWSPeer<Handler, Impl>::run()
         res.set(boost::beast::http::field::server, BuildInfo::getFullVersionString());
     }));
     impl().ws_.async_accept(
-        request_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-            capture0->onWsHandshake(std::forward<decltype(PH1)>(PH1));
+        request_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+            capture0->onWsHandshake(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -204,9 +204,13 @@ void
 BaseWSPeer<Handler, Impl>::send(std::shared_ptr<WSMsg> w)
 {
     if (!strand_.running_in_this_thread())
-        return post(strand_, [capture0 = impl().shared_from_this(), capture1 = std::move(w)] {
-            capture0->send(capture1);
-        });
+    {
+        {
+            return post(strand_, [capture0 = impl().shared_from_this(), capture1 = std::move(w)] {
+                capture0->send(capture1);
+            });
+        }
+    }
     if (doClose_)
         return;
     if (wq_.size() > port().wsQueueLimit)
@@ -299,8 +303,8 @@ BaseWSPeer<Handler, Impl>::onWrite(error_code const& ec)
         impl().ws_.async_write_some(
             static_cast<bool>(result.first),
             result.second,
-            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-                capture0->onWrite(std::forward<decltype(PH1)>(PH1));
+            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+                capture0->onWrite(std::forward<decltype(pH1)>(pH1));
             }));
     }
     else
@@ -308,8 +312,8 @@ BaseWSPeer<Handler, Impl>::onWrite(error_code const& ec)
         impl().ws_.async_write_some(
             static_cast<bool>(result.first),
             result.second,
-            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-                capture0->onWriteFin(std::forward<decltype(PH1)>(PH1));
+            bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+                capture0->onWriteFin(std::forward<decltype(pH1)>(pH1));
             }));
     }
 }
@@ -324,8 +328,8 @@ BaseWSPeer<Handler, Impl>::onWriteFin(error_code const& ec)
     if (doClose_)
     {
         impl().ws_.async_close(
-            cr_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-                capture0->onClose(std::forward<decltype(PH1)>(PH1));
+            cr_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+                capture0->onClose(std::forward<decltype(pH1)>(pH1));
             }));
     }
     else if (!wq_.empty())
@@ -341,8 +345,8 @@ BaseWSPeer<Handler, Impl>::doRead()
     if (!strand_.running_in_this_thread())
         return post(strand_, [capture0 = impl().shared_from_this()] { capture0->doRead(); });
     impl().ws_.async_read(
-        rb_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-            capture0->onRead(std::forward<decltype(PH1)>(PH1));
+        rb_, bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+            capture0->onRead(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -386,8 +390,8 @@ BaseWSPeer<Handler, Impl>::startTimer()
         return fail(e.code(), "start_timer");
     }
 
-    timer_.async_wait(bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-        capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+    timer_.async_wait(bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+        capture0->onTimer(std::forward<decltype(pH1)>(pH1));
     }));
 }
 
@@ -456,8 +460,8 @@ BaseWSPeer<Handler, Impl>::onTimer(error_code ec)
             beast::rngfill(payload_.begin(), payload_.size(), cryptoPrng());
             impl().ws_.async_ping(
                 payload_,
-                bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-                    capture0->onPing(std::forward<decltype(PH1)>(PH1));
+                bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+                    capture0->onPing(std::forward<decltype(pH1)>(pH1));
                 }));
             JLOG(this->j_.trace()) << "sent ping";
             return;

--- a/include/xrpl/server/detail/Door.h
+++ b/include/xrpl/server/detail/Door.h
@@ -33,7 +33,6 @@
 #include <algorithm>
 #include <chrono>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <sstream>
@@ -181,8 +180,8 @@ template <class Handler>
 void
 Door<Handler>::Detector::run()
 {
-    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
-        capture0->doDetect(std::forward<decltype(PH1)>(PH1));
+    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
+        capture0->doDetect(std::forward<decltype(pH1)>(pH1));
     });
 }
 
@@ -297,8 +296,8 @@ template <class Handler>
 void
 Door<Handler>::run()
 {
-    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
-        capture0->doAccept(std::forward<decltype(PH1)>(PH1));
+    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
+        capture0->doAccept(std::forward<decltype(pH1)>(pH1));
     });
 }
 

--- a/include/xrpl/server/detail/Door.h
+++ b/include/xrpl/server/detail/Door.h
@@ -181,8 +181,9 @@ template <class Handler>
 void
 Door<Handler>::Detector::run()
 {
-    util::spawn(
-        strand_, std::bind(&Detector::doDetect, this->shared_from_this(), std::placeholders::_1));
+    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
+        capture0->doDetect(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 template <class Handler>
@@ -296,9 +297,9 @@ template <class Handler>
 void
 Door<Handler>::run()
 {
-    util::spawn(
-        strand_,
-        std::bind(&Door<Handler>::doAccept, this->shared_from_this(), std::placeholders::_1));
+    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
+        capture0->doAccept(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 template <class Handler>
@@ -308,7 +309,7 @@ Door<Handler>::close()
     if (!strand_.running_in_this_thread())
     {
         return boost::asio::post(
-            strand_, std::bind(&Door<Handler>::close, this->shared_from_this()));
+            strand_, [capture0 = this->shared_from_this()] { capture0->close(); });
     }
     backoffTimer_.cancel();
     error_code ec;

--- a/include/xrpl/server/detail/Door.h
+++ b/include/xrpl/server/detail/Door.h
@@ -180,9 +180,8 @@ template <class Handler>
 void
 Door<Handler>::Detector::run()
 {
-    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
-        capture0->doDetect(std::forward<decltype(pH1)>(pH1));
-    });
+    util::spawn(
+        strand_, [self = this->shared_from_this()](yield_context yield) { self->doDetect(yield); });
 }
 
 template <class Handler>
@@ -296,9 +295,8 @@ template <class Handler>
 void
 Door<Handler>::run()
 {
-    util::spawn(strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
-        capture0->doAccept(std::forward<decltype(pH1)>(pH1));
-    });
+    util::spawn(
+        strand_, [self = this->shared_from_this()](yield_context yield) { self->doAccept(yield); });
 }
 
 template <class Handler>
@@ -307,8 +305,7 @@ Door<Handler>::close()
 {
     if (!strand_.running_in_this_thread())
     {
-        return boost::asio::post(
-            strand_, [capture0 = this->shared_from_this()] { capture0->close(); });
+        return boost::asio::post(strand_, [self = this->shared_from_this()] { self->close(); });
     }
     backoffTimer_.cancel();
     error_code ec;

--- a/include/xrpl/server/detail/PlainHTTPPeer.h
+++ b/include/xrpl/server/detail/PlainHTTPPeer.h
@@ -89,16 +89,16 @@ PlainHTTPPeer<Handler>::run()
 {
     if (!this->handler_.onAccept(this->session(), this->remoteAddress_))
     {
-        util::spawn(this->strand_, std::bind(&PlainHTTPPeer::doClose, this->shared_from_this()));
+        util::spawn(this->strand_, [capture0 = this->shared_from_this()] { capture0->doClose(); });
         return;
     }
 
     if (!socket_.is_open())
         return;
 
-    util::spawn(
-        this->strand_,
-        std::bind(&PlainHTTPPeer::doRead, this->shared_from_this(), std::placeholders::_1));
+    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
+        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 template <class Handler>

--- a/include/xrpl/server/detail/PlainHTTPPeer.h
+++ b/include/xrpl/server/detail/PlainHTTPPeer.h
@@ -9,7 +9,6 @@
 
 #include <boost/beast/core/tcp_stream.hpp>
 
-#include <functional>
 #include <memory>
 #include <utility>
 
@@ -96,8 +95,8 @@ PlainHTTPPeer<Handler>::run()
     if (!socket_.is_open())
         return;
 
-    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
-        capture0->doRead(std::forward<decltype(PH1)>(PH1));
+    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
+        capture0->doRead(std::forward<decltype(pH1)>(pH1));
     });
 }
 

--- a/include/xrpl/server/detail/PlainHTTPPeer.h
+++ b/include/xrpl/server/detail/PlainHTTPPeer.h
@@ -88,16 +88,19 @@ PlainHTTPPeer<Handler>::run()
 {
     if (!this->handler_.onAccept(this->session(), this->remoteAddress_))
     {
-        util::spawn(this->strand_, [capture0 = this->shared_from_this()] { capture0->doClose(); });
+        util::spawn(this->strand_, [self = this->shared_from_this()](boost::asio::yield_context) {
+            self->doClose();
+        });
         return;
     }
 
     if (!socket_.is_open())
         return;
 
-    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
-        capture0->doRead(std::forward<decltype(pH1)>(pH1));
-    });
+    util::spawn(
+        this->strand_, [self = this->shared_from_this()](boost::asio::yield_context doYield) {
+            self->doRead(doYield);
+        });
 }
 
 template <class Handler>

--- a/include/xrpl/server/detail/SSLHTTPPeer.h
+++ b/include/xrpl/server/detail/SSLHTTPPeer.h
@@ -13,7 +13,6 @@
 #include <boost/beast/core/tcp_stream.hpp>
 #include <boost/beast/ssl/ssl_stream.hpp>
 
-#include <functional>
 #include <memory>
 #include <utility>
 
@@ -104,8 +103,8 @@ SSLHTTPPeer<Handler>::run()
     }
     if (!socket_.is_open())
         return;
-    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
-        capture0->doHandshake(std::forward<decltype(PH1)>(PH1));
+    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
+        capture0->doHandshake(std::forward<decltype(pH1)>(pH1));
     });
 }
 
@@ -142,8 +141,8 @@ SSLHTTPPeer<Handler>::doHandshake(yield_context doYield)
         this->port().protocol.count("https") > 0;
     if (http)
     {
-        util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
-            capture0->doRead(std::forward<decltype(PH1)>(PH1));
+        util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
+            capture0->doRead(std::forward<decltype(pH1)>(pH1));
         });
         return;
     }
@@ -171,8 +170,8 @@ SSLHTTPPeer<Handler>::doClose()
 {
     this->startTimer();
     stream_.async_shutdown(
-        bind_executor(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
-            capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+        bind_executor(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
+            capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
         }));
 }
 

--- a/include/xrpl/server/detail/SSLHTTPPeer.h
+++ b/include/xrpl/server/detail/SSLHTTPPeer.h
@@ -99,14 +99,14 @@ SSLHTTPPeer<Handler>::run()
 {
     if (!this->handler_.onAccept(this->session(), this->remoteAddress_))
     {
-        util::spawn(this->strand_, std::bind(&SSLHTTPPeer::doClose, this->shared_from_this()));
+        util::spawn(this->strand_, [capture0 = this->shared_from_this()] { capture0->doClose(); });
         return;
     }
     if (!socket_.is_open())
         return;
-    util::spawn(
-        this->strand_,
-        std::bind(&SSLHTTPPeer::doHandshake, this->shared_from_this(), std::placeholders::_1));
+    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
+        capture0->doHandshake(std::forward<decltype(PH1)>(PH1));
+    });
 }
 
 template <class Handler>
@@ -142,9 +142,9 @@ SSLHTTPPeer<Handler>::doHandshake(yield_context doYield)
         this->port().protocol.count("https") > 0;
     if (http)
     {
-        util::spawn(
-            this->strand_,
-            std::bind(&SSLHTTPPeer::doRead, this->shared_from_this(), std::placeholders::_1));
+        util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
+            capture0->doRead(std::forward<decltype(PH1)>(PH1));
+        });
         return;
     }
     // `this` will be destroyed
@@ -170,9 +170,10 @@ void
 SSLHTTPPeer<Handler>::doClose()
 {
     this->startTimer();
-    stream_.async_shutdown(bind_executor(
-        this->strand_,
-        std::bind(&SSLHTTPPeer::onShutdown, this->shared_from_this(), std::placeholders::_1)));
+    stream_.async_shutdown(
+        bind_executor(this->strand_, [capture0 = this->shared_from_this()](auto&& PH1) {
+            capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 template <class Handler>

--- a/include/xrpl/server/detail/SSLHTTPPeer.h
+++ b/include/xrpl/server/detail/SSLHTTPPeer.h
@@ -98,13 +98,14 @@ SSLHTTPPeer<Handler>::run()
 {
     if (!this->handler_.onAccept(this->session(), this->remoteAddress_))
     {
-        util::spawn(this->strand_, [capture0 = this->shared_from_this()] { capture0->doClose(); });
+        util::spawn(
+            this->strand_, [self = this->shared_from_this()](yield_context) { self->doClose(); });
         return;
     }
     if (!socket_.is_open())
         return;
-    util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
-        capture0->doHandshake(std::forward<decltype(pH1)>(pH1));
+    util::spawn(this->strand_, [self = this->shared_from_this()](yield_context doYield) {
+        self->doHandshake(doYield);
     });
 }
 
@@ -141,8 +142,8 @@ SSLHTTPPeer<Handler>::doHandshake(yield_context doYield)
         this->port().protocol.count("https") > 0;
     if (http)
     {
-        util::spawn(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
-            capture0->doRead(std::forward<decltype(pH1)>(pH1));
+        util::spawn(this->strand_, [self = this->shared_from_this()](yield_context doYield) {
+            self->doRead(doYield);
         });
         return;
     }
@@ -169,10 +170,9 @@ void
 SSLHTTPPeer<Handler>::doClose()
 {
     this->startTimer();
-    stream_.async_shutdown(
-        bind_executor(this->strand_, [capture0 = this->shared_from_this()](auto&& pH1) {
-            capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
-        }));
+    stream_.async_shutdown(bind_executor(
+        this->strand_,
+        [self = this->shared_from_this()](error_code const& ec) { self->onShutdown(ec); }));
 }
 
 template <class Handler>

--- a/src/libxrpl/basics/ResolverAsio.cpp
+++ b/src/libxrpl/basics/ResolverAsio.cpp
@@ -192,7 +192,7 @@ public:
             boost::asio::dispatch(
                 ioContext,
                 boost::asio::bind_executor(
-                    strand, std::bind(&ResolverAsioImpl::doStop, this, CompletionCounter(this))));
+                    strand, [this, capture0 = CompletionCounter(this)] { doStop(capture0); }));
 
             JLOG(journal.debug()) << "Queued a stop request";
         }
@@ -221,9 +221,9 @@ public:
         boost::asio::dispatch(
             ioContext,
             boost::asio::bind_executor(
-                strand,
-                std::bind(
-                    &ResolverAsioImpl::doResolve, this, names, handler, CompletionCounter(this))));
+                strand, [this, names, handler, capture0 = CompletionCounter(this)] {
+                    doResolve(names, handler, capture0);
+                }));
     }
 
     //-------------------------------------------------------------------------
@@ -272,7 +272,7 @@ public:
         boost::asio::post(
             ioContext,
             boost::asio::bind_executor(
-                strand, std::bind(&ResolverAsioImpl::doWork, this, CompletionCounter(this))));
+                strand, [this, capture0 = CompletionCounter(this)] { doWork(capture0); }));
     }
 
     static HostAndPort
@@ -291,8 +291,10 @@ public:
         // a port separator
 
         // Attempt to find the first and last non-whitespace
-        auto const findWhitespace =
-            std::bind(&std::isspace<std::string::value_type>, std::placeholders::_1, std::locale());
+        auto const findWhitespace = [](auto&& PH1) {
+            return std::isspace<std::string::value_type>(
+                std::forward<decltype(PH1)>(PH1), std::locale());
+        };
 
         auto hostFirst = std::ranges::find_if_not(str, findWhitespace);
 
@@ -348,7 +350,7 @@ public:
             boost::asio::post(
                 ioContext,
                 boost::asio::bind_executor(
-                    strand, std::bind(&ResolverAsioImpl::doWork, this, CompletionCounter(this))));
+                    strand, [this, capture0 = CompletionCounter(this)] { doWork(capture0); }));
 
             return;
         }
@@ -356,14 +358,14 @@ public:
         resolver.async_resolve(
             host,
             port,
-            std::bind(
-                &ResolverAsioImpl::doFinish,
-                this,
-                name,
-                std::placeholders::_1,
-                handler,
-                std::placeholders::_2,
-                CompletionCounter(this)));
+            [this, name, handler, capture0 = CompletionCounter(this)](auto&& PH1, auto&& PH2) {
+                doFinish(
+                    name,
+                    std::forward<decltype(PH1)>(PH1),
+                    handler,
+                    std::forward<decltype(PH2)>(PH2),
+                    capture0);
+            });
     }
 
     void
@@ -383,8 +385,7 @@ public:
                 boost::asio::post(
                     ioContext,
                     boost::asio::bind_executor(
-                        strand,
-                        std::bind(&ResolverAsioImpl::doWork, this, CompletionCounter(this))));
+                        strand, [this, capture0 = CompletionCounter(this)] { doWork(capture0); }));
             }
         }
     }

--- a/src/libxrpl/basics/ResolverAsio.cpp
+++ b/src/libxrpl/basics/ResolverAsio.cpp
@@ -291,8 +291,9 @@ public:
         // a port separator
 
         // Attempt to find the first and last non-whitespace
-        auto const findWhitespace = [](std::string::value_type c) {
-            return std::isspace<std::string::value_type>(c, std::locale());
+        std::locale const loc;
+        auto const findWhitespace = [&loc](std::string::value_type c) {
+            return std::isspace<std::string::value_type>(c, loc);
         };
 
         auto hostFirst = std::ranges::find_if_not(str, findWhitespace);

--- a/src/libxrpl/basics/ResolverAsio.cpp
+++ b/src/libxrpl/basics/ResolverAsio.cpp
@@ -291,9 +291,9 @@ public:
         // a port separator
 
         // Attempt to find the first and last non-whitespace
-        auto const findWhitespace = [](auto&& PH1) {
+        auto const findWhitespace = [](auto&& pH1) {
             return std::isspace<std::string::value_type>(
-                std::forward<decltype(PH1)>(PH1), std::locale());
+                std::forward<decltype(pH1)>(pH1), std::locale());
         };
 
         auto hostFirst = std::ranges::find_if_not(str, findWhitespace);
@@ -358,12 +358,12 @@ public:
         resolver.async_resolve(
             host,
             port,
-            [this, name, handler, capture0 = CompletionCounter(this)](auto&& PH1, auto&& PH2) {
+            [this, name, handler, capture0 = CompletionCounter(this)](auto&& pH1, auto&& pH2) {
                 doFinish(
                     name,
-                    std::forward<decltype(PH1)>(PH1),
+                    std::forward<decltype(pH1)>(pH1),
                     handler,
-                    std::forward<decltype(PH2)>(PH2),
+                    std::forward<decltype(pH2)>(pH2),
                     capture0);
             });
     }

--- a/src/libxrpl/basics/ResolverAsio.cpp
+++ b/src/libxrpl/basics/ResolverAsio.cpp
@@ -192,7 +192,7 @@ public:
             boost::asio::dispatch(
                 ioContext,
                 boost::asio::bind_executor(
-                    strand, [this, capture0 = CompletionCounter(this)] { doStop(capture0); }));
+                    strand, [this, counter = CompletionCounter(this)] { doStop(counter); }));
 
             JLOG(journal.debug()) << "Queued a stop request";
         }
@@ -221,8 +221,8 @@ public:
         boost::asio::dispatch(
             ioContext,
             boost::asio::bind_executor(
-                strand, [this, names, handler, capture0 = CompletionCounter(this)] {
-                    doResolve(names, handler, capture0);
+                strand, [this, names, handler, counter = CompletionCounter(this)] {
+                    doResolve(names, handler, counter);
                 }));
     }
 
@@ -272,7 +272,7 @@ public:
         boost::asio::post(
             ioContext,
             boost::asio::bind_executor(
-                strand, [this, capture0 = CompletionCounter(this)] { doWork(capture0); }));
+                strand, [this, counter = CompletionCounter(this)] { doWork(counter); }));
     }
 
     static HostAndPort
@@ -291,9 +291,8 @@ public:
         // a port separator
 
         // Attempt to find the first and last non-whitespace
-        auto const findWhitespace = [](auto&& pH1) {
-            return std::isspace<std::string::value_type>(
-                std::forward<decltype(pH1)>(pH1), std::locale());
+        auto const findWhitespace = [](std::string::value_type c) {
+            return std::isspace<std::string::value_type>(c, std::locale());
         };
 
         auto hostFirst = std::ranges::find_if_not(str, findWhitespace);
@@ -350,7 +349,7 @@ public:
             boost::asio::post(
                 ioContext,
                 boost::asio::bind_executor(
-                    strand, [this, capture0 = CompletionCounter(this)] { doWork(capture0); }));
+                    strand, [this, counter = CompletionCounter(this)] { doWork(counter); }));
 
             return;
         }
@@ -358,13 +357,10 @@ public:
         resolver.async_resolve(
             host,
             port,
-            [this, name, handler, capture0 = CompletionCounter(this)](auto&& pH1, auto&& pH2) {
-                doFinish(
-                    name,
-                    std::forward<decltype(pH1)>(pH1),
-                    handler,
-                    std::forward<decltype(pH2)>(pH2),
-                    capture0);
+            [this, name, handler, counter = CompletionCounter(this)](
+                boost::system::error_code const& ec,
+                boost::asio::ip::tcp::resolver::results_type results) {
+                doFinish(name, ec, handler, results, counter);
             });
     }
 
@@ -385,7 +381,7 @@ public:
                 boost::asio::post(
                     ioContext,
                     boost::asio::bind_executor(
-                        strand, [this, capture0 = CompletionCounter(this)] { doWork(capture0); }));
+                        strand, [this, counter = CompletionCounter(this)] { doWork(counter); }));
             }
         }
     }

--- a/src/libxrpl/beast/insight/StatsDCollector.cpp
+++ b/src/libxrpl/beast/insight/StatsDCollector.cpp
@@ -325,9 +325,9 @@ public:
     postBuffer(std::string&& buffer)
     {
         boost::asio::dispatch(
-            ioContext_,
-            boost::asio::bind_executor(
-                strand_, std::bind(&StatsDCollectorImp::doPostBuffer, this, std::move(buffer))));
+            ioContext_, boost::asio::bind_executor(strand_, [this, capture0 = std::move(buffer)] {
+                doPostBuffer(capture0);
+            }));
     }
 
     // The keepAlive parameter makes sure the buffers sent to
@@ -390,14 +390,12 @@ public:
             if (!buffers.empty() && (size + length) > kMaxPacketSize)
             {
                 log(buffers);
-                socket_.async_send(
-                    buffers,
-                    std::bind(
-                        &StatsDCollectorImp::onSend,
-                        this,
+                socket_.async_send(buffers, [this, keepAlive](auto&& PH1, auto&& PH2) {
+                    onSend(
                         keepAlive,
-                        std::placeholders::_1,
-                        std::placeholders::_2));
+                        std::forward<decltype(PH1)>(PH1),
+                        std::forward<decltype(PH2)>(PH2));
+                });
                 buffers.clear();
                 size = 0;
             }
@@ -409,14 +407,10 @@ public:
         if (!buffers.empty())
         {
             log(buffers);
-            socket_.async_send(
-                buffers,
-                std::bind(
-                    &StatsDCollectorImp::onSend,
-                    this,
-                    keepAlive,
-                    std::placeholders::_1,
-                    std::placeholders::_2));
+            socket_.async_send(buffers, [this, keepAlive](auto&& PH1, auto&& PH2) {
+                onSend(
+                    keepAlive, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            });
         }
     }
 
@@ -425,7 +419,7 @@ public:
     {
         using namespace std::chrono_literals;
         timer_.expires_after(1s);
-        timer_.async_wait(std::bind(&StatsDCollectorImp::onTimer, this, std::placeholders::_1));
+        timer_.async_wait([this](auto&& PH1) { onTimer(std::forward<decltype(PH1)>(PH1)); });
     }
 
     void
@@ -513,10 +507,9 @@ StatsDCounterImpl::increment(CounterImpl::value_type amount)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        std::bind(
-            &StatsDCounterImpl::doIncrement,
-            std::static_pointer_cast<StatsDCounterImpl>(shared_from_this()),
-            amount));
+        [capture0 = std::static_pointer_cast<StatsDCounterImpl>(shared_from_this()), amount] {
+            capture0->doIncrement(amount);
+        });
 }
 
 void
@@ -558,10 +551,9 @@ StatsDEventImpl::notify(EventImpl::value_type const& value)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        std::bind(
-            &StatsDEventImpl::doNotify,
-            std::static_pointer_cast<StatsDEventImpl>(shared_from_this()),
-            value));
+        [capture0 = std::static_pointer_cast<StatsDEventImpl>(shared_from_this()), value] {
+            capture0->doNotify(value);
+        });
 }
 
 void
@@ -591,10 +583,9 @@ StatsDGaugeImpl::set(GaugeImpl::value_type value)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        std::bind(
-            &StatsDGaugeImpl::doSet,
-            std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()),
-            value));
+        [capture0 = std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()), value] {
+            capture0->doSet(value);
+        });
 }
 
 void
@@ -602,10 +593,9 @@ StatsDGaugeImpl::increment(GaugeImpl::difference_type amount)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        std::bind(
-            &StatsDGaugeImpl::doIncrement,
-            std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()),
-            amount));
+        [capture0 = std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()), amount] {
+            capture0->doIncrement(amount);
+        });
 }
 
 void
@@ -678,10 +668,9 @@ StatsDMeterImpl::increment(MeterImpl::value_type amount)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        std::bind(
-            &StatsDMeterImpl::doIncrement,
-            std::static_pointer_cast<StatsDMeterImpl>(shared_from_this()),
-            amount));
+        [capture0 = std::static_pointer_cast<StatsDMeterImpl>(shared_from_this()), amount] {
+            capture0->doIncrement(amount);
+        });
 }
 
 void

--- a/src/libxrpl/beast/insight/StatsDCollector.cpp
+++ b/src/libxrpl/beast/insight/StatsDCollector.cpp
@@ -325,8 +325,8 @@ public:
     postBuffer(std::string&& buffer)
     {
         boost::asio::dispatch(
-            ioContext_, boost::asio::bind_executor(strand_, [this, capture0 = std::move(buffer)] {
-                doPostBuffer(capture0);
+            ioContext_, boost::asio::bind_executor(strand_, [this, buffer = std::move(buffer)] {
+                doPostBuffer(buffer);
             }));
     }
 
@@ -390,12 +390,12 @@ public:
             if (!buffers.empty() && (size + length) > kMaxPacketSize)
             {
                 log(buffers);
-                socket_.async_send(buffers, [this, keepAlive](auto&& pH1, auto&& pH2) {
-                    onSend(
-                        keepAlive,
-                        std::forward<decltype(pH1)>(pH1),
-                        std::forward<decltype(pH2)>(pH2));
-                });
+                socket_.async_send(
+                    buffers,
+                    [this, keepAlive](
+                        boost::system::error_code const& ec, std::size_t bytesTransferred) {
+                        onSend(keepAlive, ec, bytesTransferred);
+                    });
                 buffers.clear();
                 size = 0;
             }
@@ -407,10 +407,12 @@ public:
         if (!buffers.empty())
         {
             log(buffers);
-            socket_.async_send(buffers, [this, keepAlive](auto&& pH1, auto&& pH2) {
-                onSend(
-                    keepAlive, std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-            });
+            socket_.async_send(
+                buffers,
+                [this, keepAlive](
+                    boost::system::error_code const& ec, std::size_t bytesTransferred) {
+                    onSend(keepAlive, ec, bytesTransferred);
+                });
         }
     }
 
@@ -419,7 +421,7 @@ public:
     {
         using namespace std::chrono_literals;
         timer_.expires_after(1s);
-        timer_.async_wait([this](auto&& pH1) { onTimer(std::forward<decltype(pH1)>(pH1)); });
+        timer_.async_wait([this](boost::system::error_code const& ec) { onTimer(ec); });
     }
 
     void
@@ -507,8 +509,8 @@ StatsDCounterImpl::increment(CounterImpl::value_type amount)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        [capture0 = std::static_pointer_cast<StatsDCounterImpl>(shared_from_this()), amount] {
-            capture0->doIncrement(amount);
+        [self = std::static_pointer_cast<StatsDCounterImpl>(shared_from_this()), amount] {
+            self->doIncrement(amount);
         });
 }
 
@@ -551,8 +553,8 @@ StatsDEventImpl::notify(EventImpl::value_type const& value)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        [capture0 = std::static_pointer_cast<StatsDEventImpl>(shared_from_this()), value] {
-            capture0->doNotify(value);
+        [self = std::static_pointer_cast<StatsDEventImpl>(shared_from_this()), value] {
+            self->doNotify(value);
         });
 }
 
@@ -583,8 +585,8 @@ StatsDGaugeImpl::set(GaugeImpl::value_type value)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        [capture0 = std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()), value] {
-            capture0->doSet(value);
+        [self = std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()), value] {
+            self->doSet(value);
         });
 }
 
@@ -593,8 +595,8 @@ StatsDGaugeImpl::increment(GaugeImpl::difference_type amount)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        [capture0 = std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()), amount] {
-            capture0->doIncrement(amount);
+        [self = std::static_pointer_cast<StatsDGaugeImpl>(shared_from_this()), amount] {
+            self->doIncrement(amount);
         });
 }
 
@@ -668,8 +670,8 @@ StatsDMeterImpl::increment(MeterImpl::value_type amount)
 {
     boost::asio::dispatch(
         impl_->getIoContext(),
-        [capture0 = std::static_pointer_cast<StatsDMeterImpl>(shared_from_this()), amount] {
-            capture0->doIncrement(amount);
+        [self = std::static_pointer_cast<StatsDMeterImpl>(shared_from_this()), amount] {
+            self->doIncrement(amount);
         });
 }
 

--- a/src/libxrpl/beast/insight/StatsDCollector.cpp
+++ b/src/libxrpl/beast/insight/StatsDCollector.cpp
@@ -390,11 +390,11 @@ public:
             if (!buffers.empty() && (size + length) > kMaxPacketSize)
             {
                 log(buffers);
-                socket_.async_send(buffers, [this, keepAlive](auto&& PH1, auto&& PH2) {
+                socket_.async_send(buffers, [this, keepAlive](auto&& pH1, auto&& pH2) {
                     onSend(
                         keepAlive,
-                        std::forward<decltype(PH1)>(PH1),
-                        std::forward<decltype(PH2)>(PH2));
+                        std::forward<decltype(pH1)>(pH1),
+                        std::forward<decltype(pH2)>(pH2));
                 });
                 buffers.clear();
                 size = 0;
@@ -407,9 +407,9 @@ public:
         if (!buffers.empty())
         {
             log(buffers);
-            socket_.async_send(buffers, [this, keepAlive](auto&& PH1, auto&& PH2) {
+            socket_.async_send(buffers, [this, keepAlive](auto&& pH1, auto&& pH2) {
                 onSend(
-                    keepAlive, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    keepAlive, std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             });
         }
     }
@@ -419,7 +419,7 @@ public:
     {
         using namespace std::chrono_literals;
         timer_.expires_after(1s);
-        timer_.async_wait([this](auto&& PH1) { onTimer(std::forward<decltype(PH1)>(PH1)); });
+        timer_.async_wait([this](auto&& pH1) { onTimer(std::forward<decltype(pH1)>(pH1)); });
     }
 
     void

--- a/src/libxrpl/core/detail/JobQueue.cpp
+++ b/src/libxrpl/core/detail/JobQueue.cpp
@@ -13,7 +13,6 @@
 
 #include <algorithm>
 #include <chrono>
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <set>

--- a/src/libxrpl/core/detail/JobQueue.cpp
+++ b/src/libxrpl/core/detail/JobQueue.cpp
@@ -36,7 +36,7 @@ JobQueue::JobQueue(
 {
     JLOG(journal_.info()) << "Using " << threadCount << "  threads";
 
-    hook_ = collector_->makeHook(std::bind(&JobQueue::collect, this));
+    hook_ = collector_->makeHook([this] { collect(); });
     jobCount_ = collector_->makeGauge("job_count");
 
     {

--- a/src/libxrpl/net/HTTPClient.cpp
+++ b/src/libxrpl/net/HTTPClient.cpp
@@ -134,9 +134,9 @@ public:
         request(
             bSSL,
             deqSites,
-            [capture0 = shared_from_this(), strPath](auto&& pH1, auto&& pH2) {
-                capture0->makeGet(
-                    strPath, std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+            [self = shared_from_this(), strPath](
+                boost::asio::streambuf& sb, std::string const& strHost) {
+                self->makeGet(strPath, sb, strHost);
             },
             timeout,
             complete);
@@ -164,8 +164,8 @@ public:
             shutdown_ = e.code();
 
             JLOG(j_.trace()) << "expires_after: " << shutdown_.message();
-            deadline_.async_wait([capture0 = shared_from_this()](auto&& pH1) {
-                capture0->handleDeadline(std::forward<decltype(pH1)>(pH1));
+            deadline_.async_wait([self = shared_from_this()](boost::system::error_code const& ec) {
+                self->handleDeadline(ec);
             });
         }
 
@@ -177,9 +177,10 @@ public:
                 query_->host,
                 query_->port,
                 query_->flags,
-                [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                    capture0->handleResolve(
-                        std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+                [self = shared_from_this()](
+                    boost::system::error_code const& ecResult,
+                    boost::asio::ip::tcp::resolver::results_type results) {
+                    self->handleResolve(ecResult, results);
                 });
         }
 
@@ -217,8 +218,8 @@ public:
             resolver_.cancel();
 
             // Stop the transaction.
-            socket_.asyncShutdown([capture0 = shared_from_this()](auto&& pH1) {
-                capture0->handleShutdown(std::forward<decltype(pH1)>(pH1));
+            socket_.asyncShutdown([self = shared_from_this()](boost::system::error_code const& ec) {
+                self->handleShutdown(ec);
             });
         }
     }
@@ -257,9 +258,11 @@ public:
             JLOG(j_.trace()) << "Resolve complete.";
 
             boost::asio::async_connect(
-                socket_.lowestLayer(), result, [capture0 = shared_from_this()](auto&& pH1) {
-                    capture0->handleConnect(std::forward<decltype(pH1)>(pH1));
-                });
+                socket_.lowestLayer(),
+                result,
+                [self = shared_from_this()](
+                    boost::system::error_code const& ecResult,
+                    boost::asio::ip::tcp::endpoint const&) { self->handleConnect(ecResult); });
         }
     }
 
@@ -296,8 +299,9 @@ public:
         else if (ssl_)
         {
             socket_.asyncHandshake(
-                AutoSocket::ssl_socket::client, [capture0 = shared_from_this()](auto&& pH1) {
-                    capture0->handleRequest(std::forward<decltype(pH1)>(pH1));
+                AutoSocket::ssl_socket::client,
+                [self = shared_from_this()](boost::system::error_code const& ec) {
+                    self->handleRequest(ec);
                 });
         }
         else
@@ -324,10 +328,12 @@ public:
 
             build_(request_, deqSites_[0]);
 
-            socket_.asyncWrite(request_, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                capture0->handleWrite(
-                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-            });
+            socket_.asyncWrite(
+                request_,
+                [self = shared_from_this()](
+                    boost::system::error_code const& ecResult, std::size_t bytesTransferred) {
+                    self->handleWrite(ecResult, bytesTransferred);
+                });
         }
     }
 
@@ -348,9 +354,11 @@ public:
             JLOG(j_.trace()) << "Wrote.";
 
             socket_.asyncReadUntil(
-                header_, "\r\n\r\n", [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                    capture0->handleHeader(
-                        std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+                header_,
+                "\r\n\r\n",
+                [self = shared_from_this()](
+                    boost::system::error_code const& ecResult, std::size_t bytesTransferred) {
+                    self->handleHeader(ecResult, bytesTransferred);
                 });
         }
     }
@@ -414,9 +422,9 @@ public:
             socket_.asyncRead(
                 response_.prepare(responseSize - body_.size()),
                 boost::asio::transfer_all(),
-                [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                    capture0->handleData(
-                        std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+                [self = shared_from_this()](
+                    boost::system::error_code const& ecResult, std::size_t bytesTransferred) {
+                    self->handleData(ecResult, bytesTransferred);
                 });
         }
     }

--- a/src/libxrpl/net/HTTPClient.cpp
+++ b/src/libxrpl/net/HTTPClient.cpp
@@ -134,9 +134,9 @@ public:
         request(
             bSSL,
             deqSites,
-            [capture0 = shared_from_this(), strPath](auto&& PH1, auto&& PH2) {
+            [capture0 = shared_from_this(), strPath](auto&& pH1, auto&& pH2) {
                 capture0->makeGet(
-                    strPath, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    strPath, std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             },
             timeout,
             complete);
@@ -164,8 +164,8 @@ public:
             shutdown_ = e.code();
 
             JLOG(j_.trace()) << "expires_after: " << shutdown_.message();
-            deadline_.async_wait([capture0 = shared_from_this()](auto&& PH1) {
-                capture0->handleDeadline(std::forward<decltype(PH1)>(PH1));
+            deadline_.async_wait([capture0 = shared_from_this()](auto&& pH1) {
+                capture0->handleDeadline(std::forward<decltype(pH1)>(pH1));
             });
         }
 
@@ -177,9 +177,9 @@ public:
                 query_->host,
                 query_->port,
                 query_->flags,
-                [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                     capture0->handleResolve(
-                        std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                        std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                 });
         }
 
@@ -217,8 +217,8 @@ public:
             resolver_.cancel();
 
             // Stop the transaction.
-            socket_.asyncShutdown([capture0 = shared_from_this()](auto&& PH1) {
-                capture0->handleShutdown(std::forward<decltype(PH1)>(PH1));
+            socket_.asyncShutdown([capture0 = shared_from_this()](auto&& pH1) {
+                capture0->handleShutdown(std::forward<decltype(pH1)>(pH1));
             });
         }
     }
@@ -257,8 +257,8 @@ public:
             JLOG(j_.trace()) << "Resolve complete.";
 
             boost::asio::async_connect(
-                socket_.lowestLayer(), result, [capture0 = shared_from_this()](auto&& PH1) {
-                    capture0->handleConnect(std::forward<decltype(PH1)>(PH1));
+                socket_.lowestLayer(), result, [capture0 = shared_from_this()](auto&& pH1) {
+                    capture0->handleConnect(std::forward<decltype(pH1)>(pH1));
                 });
         }
     }
@@ -296,8 +296,8 @@ public:
         else if (ssl_)
         {
             socket_.asyncHandshake(
-                AutoSocket::ssl_socket::client, [capture0 = shared_from_this()](auto&& PH1) {
-                    capture0->handleRequest(std::forward<decltype(PH1)>(PH1));
+                AutoSocket::ssl_socket::client, [capture0 = shared_from_this()](auto&& pH1) {
+                    capture0->handleRequest(std::forward<decltype(pH1)>(pH1));
                 });
         }
         else
@@ -324,9 +324,9 @@ public:
 
             build_(request_, deqSites_[0]);
 
-            socket_.asyncWrite(request_, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+            socket_.asyncWrite(request_, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                 capture0->handleWrite(
-                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             });
         }
     }
@@ -348,9 +348,9 @@ public:
             JLOG(j_.trace()) << "Wrote.";
 
             socket_.asyncReadUntil(
-                header_, "\r\n\r\n", [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                header_, "\r\n\r\n", [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                     capture0->handleHeader(
-                        std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                        std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                 });
         }
     }
@@ -414,9 +414,9 @@ public:
             socket_.asyncRead(
                 response_.prepare(responseSize - body_.size()),
                 boost::asio::transfer_all(),
-                [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                     capture0->handleData(
-                        std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                        std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                 });
         }
     }

--- a/src/libxrpl/net/HTTPClient.cpp
+++ b/src/libxrpl/net/HTTPClient.cpp
@@ -134,12 +134,10 @@ public:
         request(
             bSSL,
             deqSites,
-            std::bind(
-                &HTTPClientImp::makeGet,
-                shared_from_this(),
-                strPath,
-                std::placeholders::_1,
-                std::placeholders::_2),
+            [capture0 = shared_from_this(), strPath](auto&& PH1, auto&& PH2) {
+                capture0->makeGet(
+                    strPath, std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            },
             timeout,
             complete);
     }
@@ -166,9 +164,9 @@ public:
             shutdown_ = e.code();
 
             JLOG(j_.trace()) << "expires_after: " << shutdown_.message();
-            deadline_.async_wait(
-                std::bind(
-                    &HTTPClientImp::handleDeadline, shared_from_this(), std::placeholders::_1));
+            deadline_.async_wait([capture0 = shared_from_this()](auto&& PH1) {
+                capture0->handleDeadline(std::forward<decltype(PH1)>(PH1));
+            });
         }
 
         if (!shutdown_)
@@ -179,11 +177,10 @@ public:
                 query_->host,
                 query_->port,
                 query_->flags,
-                std::bind(
-                    &HTTPClientImp::handleResolve,
-                    shared_from_this(),
-                    std::placeholders::_1,
-                    std::placeholders::_2));
+                [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    capture0->handleResolve(
+                        std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                });
         }
 
         if (shutdown_)
@@ -220,9 +217,9 @@ public:
             resolver_.cancel();
 
             // Stop the transaction.
-            socket_.asyncShutdown(
-                std::bind(
-                    &HTTPClientImp::handleShutdown, shared_from_this(), std::placeholders::_1));
+            socket_.asyncShutdown([capture0 = shared_from_this()](auto&& PH1) {
+                capture0->handleShutdown(std::forward<decltype(PH1)>(PH1));
+            });
         }
     }
 
@@ -260,10 +257,9 @@ public:
             JLOG(j_.trace()) << "Resolve complete.";
 
             boost::asio::async_connect(
-                socket_.lowestLayer(),
-                result,
-                std::bind(
-                    &HTTPClientImp::handleConnect, shared_from_this(), std::placeholders::_1));
+                socket_.lowestLayer(), result, [capture0 = shared_from_this()](auto&& PH1) {
+                    capture0->handleConnect(std::forward<decltype(PH1)>(PH1));
+                });
         }
     }
 
@@ -300,9 +296,9 @@ public:
         else if (ssl_)
         {
             socket_.asyncHandshake(
-                AutoSocket::ssl_socket::client,
-                std::bind(
-                    &HTTPClientImp::handleRequest, shared_from_this(), std::placeholders::_1));
+                AutoSocket::ssl_socket::client, [capture0 = shared_from_this()](auto&& PH1) {
+                    capture0->handleRequest(std::forward<decltype(PH1)>(PH1));
+                });
         }
         else
         {
@@ -328,13 +324,10 @@ public:
 
             build_(request_, deqSites_[0]);
 
-            socket_.asyncWrite(
-                request_,
-                std::bind(
-                    &HTTPClientImp::handleWrite,
-                    shared_from_this(),
-                    std::placeholders::_1,
-                    std::placeholders::_2));
+            socket_.asyncWrite(request_, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                capture0->handleWrite(
+                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            });
         }
     }
 
@@ -355,13 +348,10 @@ public:
             JLOG(j_.trace()) << "Wrote.";
 
             socket_.asyncReadUntil(
-                header_,
-                "\r\n\r\n",
-                std::bind(
-                    &HTTPClientImp::handleHeader,
-                    shared_from_this(),
-                    std::placeholders::_1,
-                    std::placeholders::_2));
+                header_, "\r\n\r\n", [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    capture0->handleHeader(
+                        std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                });
         }
     }
 
@@ -424,11 +414,10 @@ public:
             socket_.asyncRead(
                 response_.prepare(responseSize - body_.size()),
                 boost::asio::transfer_all(),
-                std::bind(
-                    &HTTPClientImp::handleData,
-                    shared_from_this(),
-                    std::placeholders::_1,
-                    std::placeholders::_2));
+                [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    capture0->handleData(
+                        std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                });
         }
     }
 

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -171,8 +171,8 @@ public:
                             req.set(h.first, h.second);
                     }));
             ws_.handshake(ep.address().to_string() + ":" + std::to_string(ep.port()), "/");
-            ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& PH1) {
-                               onReadMsg(std::forward<decltype(PH1)>(PH1));
+            ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& pH1) {
+                               onReadMsg(std::forward<decltype(pH1)>(pH1));
                            }));
         }
         catch (std::exception&)
@@ -308,8 +308,8 @@ private:
             msgs_.push_front(m);
             cv_.notify_all();
         }
-        ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& PH1) {
-                           onReadMsg(std::forward<decltype(PH1)>(PH1));
+        ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& pH1) {
+                           onReadMsg(std::forward<decltype(pH1)>(pH1));
                        }));
     }
 

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <condition_variable>
+#include <cstddef>
 #include <exception>
 #include <functional>
 #include <iostream>
@@ -171,9 +172,10 @@ public:
                             req.set(h.first, h.second);
                     }));
             ws_.handshake(ep.address().to_string() + ":" + std::to_string(ep.port()), "/");
-            ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& pH1) {
-                               onReadMsg(std::forward<decltype(pH1)>(pH1));
-                           }));
+            ws_.async_read(
+                rb_, boost::asio::bind_executor(strand_, [this](error_code const& ec, std::size_t) {
+                    onReadMsg(ec);
+                }));
         }
         catch (std::exception&)
         {
@@ -308,9 +310,10 @@ private:
             msgs_.push_front(m);
             cv_.notify_all();
         }
-        ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& pH1) {
-                           onReadMsg(std::forward<decltype(pH1)>(pH1));
-                       }));
+        ws_.async_read(
+            rb_, boost::asio::bind_executor(strand_, [this](error_code const& ec, std::size_t) {
+                onReadMsg(ec);
+            }));
     }
 
     // Called when the read op terminates

--- a/src/test/jtx/impl/WSClient.cpp
+++ b/src/test/jtx/impl/WSClient.cpp
@@ -171,10 +171,9 @@ public:
                             req.set(h.first, h.second);
                     }));
             ws_.handshake(ep.address().to_string() + ":" + std::to_string(ep.port()), "/");
-            ws_.async_read(
-                rb_,
-                boost::asio::bind_executor(
-                    strand_, std::bind(&WSClientImpl::onReadMsg, this, std::placeholders::_1)));
+            ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& PH1) {
+                               onReadMsg(std::forward<decltype(PH1)>(PH1));
+                           }));
         }
         catch (std::exception&)
         {
@@ -309,10 +308,9 @@ private:
             msgs_.push_front(m);
             cv_.notify_all();
         }
-        ws_.async_read(
-            rb_,
-            boost::asio::bind_executor(
-                strand_, std::bind(&WSClientImpl::onReadMsg, this, std::placeholders::_1)));
+        ws_.async_read(rb_, boost::asio::bind_executor(strand_, [this](auto&& PH1) {
+                           onReadMsg(std::forward<decltype(PH1)>(PH1));
+                       }));
     }
 
     // Called when the read op terminates

--- a/src/test/overlay/short_read_test.cpp
+++ b/src/test/overlay/short_read_test.cpp
@@ -546,8 +546,7 @@ private:
 #else
                 stream_.async_shutdown(bind_executor(
                     strand_,
-                    std::bind(
-                        &Connection::on_shutdown, shared_from_this(), std::placeholders::_1)));
+                    [self = shared_from_this()](error_code const& ec) { self->on_shutdown(ec); }));
 #endif
             }
 
@@ -574,8 +573,7 @@ private:
 #else
                 stream_.async_shutdown(bind_executor(
                     strand_,
-                    std::bind(
-                        &Connection::on_shutdown, shared_from_this(), std::placeholders::_1)));
+                    [self = shared_from_this()](error_code const& ec) { self->on_shutdown(ec); }));
 #endif
             }
 

--- a/src/test/overlay/short_read_test.cpp
+++ b/src/test/overlay/short_read_test.cpp
@@ -198,7 +198,7 @@ private:
             {
                 if (!strand.running_in_this_thread())
                 {
-                    post(strand, [capture0 = shared_from_this()] { capture0->close(); });
+                    post(strand, [self = shared_from_this()] { self->close(); });
                     return;
                 }
                 acceptor.close();
@@ -208,8 +208,9 @@ private:
             run()
             {
                 acceptor.async_accept(
-                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onAccept(std::forward<decltype(pH1)>(pH1));
+                    socket,
+                    bind_executor(strand, [self = shared_from_this()](error_code const& ec) {
+                        self->onAccept(ec);
                     }));
             }
 
@@ -236,8 +237,9 @@ private:
                 server.add(p);
                 p->run();
                 acceptor.async_accept(
-                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onAccept(std::forward<decltype(pH1)>(pH1));
+                    socket,
+                    bind_executor(strand, [self = shared_from_this()](error_code const& ec) {
+                        self->onAccept(ec);
                     }));
             }
         };
@@ -268,7 +270,7 @@ private:
             {
                 if (!strand.running_in_this_thread())
                 {
-                    post(strand, [capture0 = shared_from_this()] { capture0->close(); });
+                    post(strand, [self = shared_from_this()] { self->close(); });
                     return;
                 }
                 if (socket.is_open())
@@ -282,13 +284,13 @@ private:
             run()
             {
                 timer.expires_after(std::chrono::seconds(3));
-                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                    capture0->onTimer(std::forward<decltype(pH1)>(pH1));
-                }));
+                timer.async_wait(bind_executor(
+                    strand,
+                    [self = shared_from_this()](error_code const& ec) { self->onTimer(ec); }));
                 stream.async_handshake(
                     stream_type::server,
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
+                    bind_executor(strand, [self = shared_from_this()](error_code const& ec) {
+                        self->onHandshake(ec);
                     }));
             }
 
@@ -331,10 +333,12 @@ private:
                     stream,
                     buf,
                     "\n",
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                        capture0->onRead(
-                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-                    }));
+                    bind_executor(
+                        strand,
+                        [self = shared_from_this()](
+                            error_code const& ec, std::size_t bytesTransferred) {
+                            self->onRead(ec, bytesTransferred);
+                        }));
 #else
                 close();
 #endif
@@ -347,8 +351,8 @@ private:
                 {
                     server.test_.log << "[server] read: EOF" << std::endl;
                     stream.async_shutdown(
-                        bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                            capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
+                        bind_executor(strand, [self = shared_from_this()](error_code const& ec) {
+                            self->onShutdown(ec);
                         }));
                     return;
                 }
@@ -364,10 +368,12 @@ private:
                 boost::asio::async_write(
                     stream,
                     buf.data(),
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                        capture0->onWrite(
-                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-                    }));
+                    bind_executor(
+                        strand,
+                        [self = shared_from_this()](
+                            error_code const& ec, std::size_t bytesTransferred) {
+                            self->onWrite(ec, bytesTransferred);
+                        }));
             }
 
             void
@@ -379,10 +385,9 @@ private:
                     fail("write", ec);
                     return;
                 }
-                stream.async_shutdown(
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
-                    }));
+                stream.async_shutdown(bind_executor(
+                    strand,
+                    [self = shared_from_this()](error_code const& ec) { self->onShutdown(ec); }));
             }
 
             void
@@ -454,7 +459,7 @@ private:
             {
                 if (!strand.running_in_this_thread())
                 {
-                    post(strand, [capture0 = shared_from_this()] { capture0->close(); });
+                    post(strand, [self = shared_from_this()] { self->close(); });
                     return;
                 }
                 if (socket.is_open())
@@ -468,12 +473,12 @@ private:
             run(endpoint_type const& ep)
             {
                 timer.expires_after(std::chrono::seconds(3));
-                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                    capture0->onTimer(std::forward<decltype(pH1)>(pH1));
-                }));
+                timer.async_wait(bind_executor(
+                    strand,
+                    [self = shared_from_this()](error_code const& ec) { self->onTimer(ec); }));
                 socket.async_connect(
-                    ep, bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onConnect(std::forward<decltype(pH1)>(pH1));
+                    ep, bind_executor(strand, [self = shared_from_this()](error_code const& ec) {
+                        self->onConnect(ec);
                     }));
             }
 
@@ -513,8 +518,8 @@ private:
                 }
                 stream.async_handshake(
                     stream_type::client,
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
+                    bind_executor(strand, [self = shared_from_this()](error_code const& ec) {
+                        self->onHandshake(ec);
                     }));
             }
 
@@ -532,10 +537,12 @@ private:
                 boost::asio::async_write(
                     stream,
                     buf.data(),
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                        capture0->onWrite(
-                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-                    }));
+                    bind_executor(
+                        strand,
+                        [self = shared_from_this()](
+                            error_code const& ec, std::size_t bytesTransferred) {
+                            self->onWrite(ec, bytesTransferred);
+                        }));
 #else
                 stream_.async_shutdown(bind_executor(
                     strand_,
@@ -558,10 +565,12 @@ private:
                     stream,
                     buf,
                     "\n",
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                        capture0->onRead(
-                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-                    }));
+                    bind_executor(
+                        strand,
+                        [self = shared_from_this()](
+                            error_code const& ec, std::size_t bytesTransferred) {
+                            self->onRead(ec, bytesTransferred);
+                        }));
 #else
                 stream_.async_shutdown(bind_executor(
                     strand_,
@@ -579,10 +588,9 @@ private:
                     return;
                 }
                 buf.commit(bytesTransferred);
-                stream.async_shutdown(
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
-                        capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
-                    }));
+                stream.async_shutdown(bind_executor(
+                    strand,
+                    [self = shared_from_this()](error_code const& ec) { self->onShutdown(ec); }));
             }
 
             void

--- a/src/test/overlay/short_read_test.cpp
+++ b/src/test/overlay/short_read_test.cpp
@@ -199,7 +199,7 @@ private:
             {
                 if (!strand.running_in_this_thread())
                 {
-                    post(strand, std::bind(&Acceptor::close, shared_from_this()));
+                    post(strand, [capture0 = shared_from_this()] { capture0->close(); });
                     return;
                 }
                 acceptor.close();
@@ -209,10 +209,9 @@ private:
             run()
             {
                 acceptor.async_accept(
-                    socket,
-                    bind_executor(
-                        strand,
-                        std::bind(&Acceptor::onAccept, shared_from_this(), std::placeholders::_1)));
+                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onAccept(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
 
             void
@@ -238,10 +237,9 @@ private:
                 server.add(p);
                 p->run();
                 acceptor.async_accept(
-                    socket,
-                    bind_executor(
-                        strand,
-                        std::bind(&Acceptor::onAccept, shared_from_this(), std::placeholders::_1)));
+                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onAccept(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
         };
 
@@ -271,7 +269,7 @@ private:
             {
                 if (!strand.running_in_this_thread())
                 {
-                    post(strand, std::bind(&Connection::close, shared_from_this()));
+                    post(strand, [capture0 = shared_from_this()] { capture0->close(); });
                     return;
                 }
                 if (socket.is_open())
@@ -285,15 +283,14 @@ private:
             run()
             {
                 timer.expires_after(std::chrono::seconds(3));
-                timer.async_wait(bind_executor(
-                    strand,
-                    std::bind(&Connection::onTimer, shared_from_this(), std::placeholders::_1)));
+                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                    capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+                }));
                 stream.async_handshake(
                     stream_type::server,
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onHandshake, shared_from_this(), std::placeholders::_1)));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
 
             void
@@ -335,13 +332,10 @@ private:
                     stream,
                     buf,
                     "\n",
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onRead,
-                            shared_from_this(),
-                            std::placeholders::_1,
-                            std::placeholders::_2)));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                        capture0->onRead(
+                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    }));
 #else
                 close();
 #endif
@@ -353,10 +347,10 @@ private:
                 if (ec == boost::asio::error::eof)
                 {
                     server.test_.log << "[server] read: EOF" << std::endl;
-                    stream.async_shutdown(bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onShutdown, shared_from_this(), std::placeholders::_1)));
+                    stream.async_shutdown(
+                        bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                            capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                        }));
                     return;
                 }
                 if (ec)
@@ -371,13 +365,10 @@ private:
                 boost::asio::async_write(
                     stream,
                     buf.data(),
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onWrite,
-                            shared_from_this(),
-                            std::placeholders::_1,
-                            std::placeholders::_2)));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                        capture0->onWrite(
+                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    }));
             }
 
             void
@@ -389,9 +380,10 @@ private:
                     fail("write", ec);
                     return;
                 }
-                stream.async_shutdown(bind_executor(
-                    strand,
-                    std::bind(&Connection::onShutdown, shared_from_this(), std::placeholders::_1)));
+                stream.async_shutdown(
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
 
             void
@@ -463,7 +455,7 @@ private:
             {
                 if (!strand.running_in_this_thread())
                 {
-                    post(strand, std::bind(&Connection::close, shared_from_this()));
+                    post(strand, [capture0 = shared_from_this()] { capture0->close(); });
                     return;
                 }
                 if (socket.is_open())
@@ -477,15 +469,13 @@ private:
             run(endpoint_type const& ep)
             {
                 timer.expires_after(std::chrono::seconds(3));
-                timer.async_wait(bind_executor(
-                    strand,
-                    std::bind(&Connection::onTimer, shared_from_this(), std::placeholders::_1)));
+                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                    capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+                }));
                 socket.async_connect(
-                    ep,
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onConnect, shared_from_this(), std::placeholders::_1)));
+                    ep, bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onConnect(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
 
             void
@@ -524,10 +514,9 @@ private:
                 }
                 stream.async_handshake(
                     stream_type::client,
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onHandshake, shared_from_this(), std::placeholders::_1)));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
 
             void
@@ -544,13 +533,10 @@ private:
                 boost::asio::async_write(
                     stream,
                     buf.data(),
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onWrite,
-                            shared_from_this(),
-                            std::placeholders::_1,
-                            std::placeholders::_2)));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                        capture0->onWrite(
+                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    }));
 #else
                 stream_.async_shutdown(bind_executor(
                     strand_,
@@ -573,13 +559,10 @@ private:
                     stream,
                     buf,
                     "\n",
-                    bind_executor(
-                        strand,
-                        std::bind(
-                            &Connection::onRead,
-                            shared_from_this(),
-                            std::placeholders::_1,
-                            std::placeholders::_2)));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                        capture0->onRead(
+                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    }));
 #else
                 stream_.async_shutdown(bind_executor(
                     strand_,
@@ -597,9 +580,10 @@ private:
                     return;
                 }
                 buf.commit(bytesTransferred);
-                stream.async_shutdown(bind_executor(
-                    strand,
-                    std::bind(&Connection::onShutdown, shared_from_this(), std::placeholders::_1)));
+                stream.async_shutdown(
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
+                        capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                    }));
             }
 
             void

--- a/src/test/overlay/short_read_test.cpp
+++ b/src/test/overlay/short_read_test.cpp
@@ -26,7 +26,6 @@
 #include <chrono>
 #include <condition_variable>
 #include <cstddef>
-#include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
@@ -209,8 +208,8 @@ private:
             run()
             {
                 acceptor.async_accept(
-                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onAccept(std::forward<decltype(PH1)>(PH1));
+                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onAccept(std::forward<decltype(pH1)>(pH1));
                     }));
             }
 
@@ -237,8 +236,8 @@ private:
                 server.add(p);
                 p->run();
                 acceptor.async_accept(
-                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onAccept(std::forward<decltype(PH1)>(PH1));
+                    socket, bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onAccept(std::forward<decltype(pH1)>(pH1));
                     }));
             }
         };
@@ -283,13 +282,13 @@ private:
             run()
             {
                 timer.expires_after(std::chrono::seconds(3));
-                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                    capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                    capture0->onTimer(std::forward<decltype(pH1)>(pH1));
                 }));
                 stream.async_handshake(
                     stream_type::server,
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
                     }));
             }
 
@@ -332,9 +331,9 @@ private:
                     stream,
                     buf,
                     "\n",
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                         capture0->onRead(
-                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                     }));
 #else
                 close();
@@ -348,8 +347,8 @@ private:
                 {
                     server.test_.log << "[server] read: EOF" << std::endl;
                     stream.async_shutdown(
-                        bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                            capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                        bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                            capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
                         }));
                     return;
                 }
@@ -365,9 +364,9 @@ private:
                 boost::asio::async_write(
                     stream,
                     buf.data(),
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                         capture0->onWrite(
-                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                     }));
             }
 
@@ -381,8 +380,8 @@ private:
                     return;
                 }
                 stream.async_shutdown(
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
                     }));
             }
 
@@ -469,12 +468,12 @@ private:
             run(endpoint_type const& ep)
             {
                 timer.expires_after(std::chrono::seconds(3));
-                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                    capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+                timer.async_wait(bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                    capture0->onTimer(std::forward<decltype(pH1)>(pH1));
                 }));
                 socket.async_connect(
-                    ep, bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onConnect(std::forward<decltype(PH1)>(PH1));
+                    ep, bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onConnect(std::forward<decltype(pH1)>(pH1));
                     }));
             }
 
@@ -514,8 +513,8 @@ private:
                 }
                 stream.async_handshake(
                     stream_type::client,
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
                     }));
             }
 
@@ -533,9 +532,9 @@ private:
                 boost::asio::async_write(
                     stream,
                     buf.data(),
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                         capture0->onWrite(
-                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                     }));
 #else
                 stream_.async_shutdown(bind_executor(
@@ -559,9 +558,9 @@ private:
                     stream,
                     buf,
                     "\n",
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                         capture0->onRead(
-                            std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                            std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
                     }));
 #else
                 stream_.async_shutdown(bind_executor(
@@ -581,8 +580,8 @@ private:
                 }
                 buf.commit(bytesTransferred);
                 stream.async_shutdown(
-                    bind_executor(strand, [capture0 = shared_from_this()](auto&& PH1) {
-                        capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                    bind_executor(strand, [capture0 = shared_from_this()](auto&& pH1) {
+                        capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
                     }));
             }
 

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -90,8 +90,8 @@ public:
         beast::IP::Endpoint const addr(beast::IP::Endpoint::fromString("192.0.2.2"));
 
         std::function<Consumer(beast::IP::Endpoint)> const ep = limited
-            ? [ObjectPtr = &logic](auto && PH1) { return ObjectPtr->newInboundEndpoint(std::forward<decltype(PH1)>(PH1)); }
-            : [ObjectPtr = &logic](auto && PH1) { return ObjectPtr->newUnlimitedEndpoint(std::forward<decltype(PH1)>(PH1)); };
+            ? [objectPtr = &logic](auto && pH1) { return objectPtr->newInboundEndpoint(std::forward<decltype(pH1)>(pH1)); }
+            : [objectPtr = &logic](auto && pH1) { return objectPtr->newUnlimitedEndpoint(std::forward<decltype(pH1)>(pH1)); };
 
         {
             Consumer c(ep(addr));

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -89,9 +89,11 @@ public:
         Charge const fee(kDropThreshold + 1);
         beast::IP::Endpoint const addr(beast::IP::Endpoint::fromString("192.0.2.2"));
 
-        std::function<Consumer(beast::IP::Endpoint)> const ep = limited
-            ? [objectPtr = &logic](auto && pH1) { return objectPtr->newInboundEndpoint(std::forward<decltype(pH1)>(pH1)); }
-            : [objectPtr = &logic](auto && pH1) { return objectPtr->newUnlimitedEndpoint(std::forward<decltype(pH1)>(pH1)); };
+        std::function<Consumer(beast::IP::Endpoint)> const ep =
+            [&logic, limited](beast::IP::Endpoint const& address) {
+                return limited ? logic.newInboundEndpoint(address)
+                               : logic.newUnlimitedEndpoint(address);
+            };
 
         {
             Consumer c(ep(addr));

--- a/src/test/resource/Logic_test.cpp
+++ b/src/test/resource/Logic_test.cpp
@@ -90,8 +90,8 @@ public:
         beast::IP::Endpoint const addr(beast::IP::Endpoint::fromString("192.0.2.2"));
 
         std::function<Consumer(beast::IP::Endpoint)> const ep = limited
-            ? std::bind(&TestLogic::newInboundEndpoint, &logic, std::placeholders::_1)
-            : std::bind(&TestLogic::newUnlimitedEndpoint, &logic, std::placeholders::_1);
+            ? [ObjectPtr = &logic](auto && PH1) { return ObjectPtr->newInboundEndpoint(std::forward<decltype(PH1)>(PH1)); }
+            : [ObjectPtr = &logic](auto && PH1) { return ObjectPtr->newUnlimitedEndpoint(std::forward<decltype(PH1)>(PH1)); };
 
         {
             Consumer c(ep(addr));

--- a/src/test/rpc/AccountTx_test.cpp
+++ b/src/test/rpc/AccountTx_test.cpp
@@ -41,7 +41,6 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <initializer_list>
 #include <iterator>
 #include <memory>
@@ -893,7 +892,7 @@ public:
     void
     run() override
     {
-        forAllApiVersions(std::bind_front(&AccountTx_test::testParameters, this));
+        forAllApiVersions([this](unsigned apiVersion) { testParameters(apiVersion); });
         testContents();
         testAccountDelete();
         testMPT();

--- a/src/test/rpc/LedgerRequest_test.cpp
+++ b/src/test/rpc/LedgerRequest_test.cpp
@@ -11,7 +11,6 @@
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
 
-#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -350,7 +349,7 @@ public:
     {
         testLedgerRequest();
         testEvolution();
-        forAllApiVersions(std::bind_front(&LedgerRequest_test::testBadInput, this));
+        forAllApiVersions([this](unsigned apiVersion) { testBadInput(apiVersion); });
         testMoreThan256Closed();
         testNonAdmin();
     }

--- a/src/test/rpc/RPCCall_test.cpp
+++ b/src/test/rpc/RPCCall_test.cpp
@@ -14,7 +14,6 @@
 
 #include <cstdint>
 #include <cstring>
-#include <functional>
 #include <initializer_list>
 #include <memory>
 #include <string>
@@ -5927,7 +5926,7 @@ public:
     void
     run() override
     {
-        forAllApiVersions(std::bind_front(&RPCCall_test::testRPCCall, this));
+        forAllApiVersions([this](unsigned apiVersion) { testRPCCall(apiVersion); });
     }
 };
 

--- a/src/test/rpc/TransactionEntry_test.cpp
+++ b/src/test/rpc/TransactionEntry_test.cpp
@@ -17,7 +17,6 @@
 #include <xrpl/protocol/ErrorCodes.h>
 #include <xrpl/protocol/jss.h>
 
-#include <functional>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -353,7 +352,7 @@ public:
     run() override
     {
         testBadInput();
-        forAllApiVersions(std::bind_front(&TransactionEntry_test::testRequest, this));
+        forAllApiVersions([this](unsigned apiVersion) { testRequest(apiVersion); });
     }
 };
 

--- a/src/test/rpc/Transaction_test.cpp
+++ b/src/test/rpc/Transaction_test.cpp
@@ -31,7 +31,6 @@
 #include <cctype>
 #include <cstddef>
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -886,7 +885,7 @@ public:
     run() override
     {
         using namespace test::jtx;
-        forAllApiVersions(std::bind_front(&Transaction_test::testBinaryRequest, this));
+        forAllApiVersions([this](unsigned apiVersion) { testBinaryRequest(apiVersion); });
 
         FeatureBitset const all{testableAmendments()};
         testWithFeats(all);
@@ -899,7 +898,8 @@ public:
         testRangeCTIDRequest(features);
         testCTIDValidation(features);
         testRPCsForCTID(features);
-        forAllApiVersions(std::bind_front(&Transaction_test::testRequest, this, features));
+        forAllApiVersions(
+            [this, features](unsigned apiVersion) { testRequest(features, apiVersion); });
     }
 };
 

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -82,7 +82,7 @@ public:
     static void
     addRandomItems(std::size_t n, Table& t, beast::xor_shift_engine& r)
     {
-        while ((n--) != 0u)
+        for (std::size_t i = 0; i < n; ++i)
         {
             auto const result(t.addItem(SHAMapNodeType::TnAccountState, makeRandomItemMember(r)));
             assert(result);

--- a/src/test/shamap/FetchPack_test.cpp
+++ b/src/test/shamap/FetchPack_test.cpp
@@ -6,7 +6,6 @@
 #include <xrpl/basics/SHAMapHash.h>
 #include <xrpl/basics/Slice.h>
 #include <xrpl/basics/UnorderedContainers.h>
-#include <xrpl/basics/contract.h>
 #include <xrpl/basics/random.h>
 #include <xrpl/beast/unit_test/suite.h>
 #include <xrpl/beast/utility/Journal.h>
@@ -26,7 +25,6 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
-#include <stdexcept>
 
 namespace xrpl::tests {
 
@@ -39,15 +37,6 @@ public:
     using Map = hash_map<SHAMapHash, Blob>;
     using Table = SHAMap;
     using Item = SHAMapItem;
-
-    struct Handler
-    {
-        void
-        operator()(std::uint32_t refNum) const
-        {
-            Throw<std::runtime_error>("missing node");
-        }
-    };
 
     struct TestFilter : SHAMapSyncFilter
     {
@@ -111,56 +100,51 @@ public:
     void
     run() override
     {
-        using beast::Severity;
+        testFetchPack();
+    }
+
+    // Exercises a fetch-pack round trip: build a SHAMap, serialize every node
+    // into a pack keyed by node hash, then rebuild the map in a fresh SHAMap by
+    // sourcing every node from the pack through a SHAMapSyncFilter and comparing
+    // the result. This covers the filter-based reconstruction path (fetchRoot +
+    // getMissingNodes with a SHAMapSyncFilter), complementing SHAMapSync_test,
+    // which drives the getNodeFat/addKnownNode path.
+    void
+    testFetchPack()
+    {
         test::SuiteJournal journal("FetchPack_test", *this);
+        TestNodeFamily f(journal), f2(journal);
+        beast::xor_shift_engine r;
 
-        TestNodeFamily f(journal);
-        std::shared_ptr<Table> const t1(std::make_shared<Table>(SHAMapType::FREE, f));
+        // Build a source map. getHash() unshares the tree and computes every
+        // node hash; this must happen before serializing nodes below, otherwise
+        // inner nodes still carry stale cached hashes.
+        auto const source = std::make_shared<Table>(SHAMapType::FREE, f);
+        addRandomItems(kTableItems + kTableItemsExtra, *source, r);
+        source->setImmutable();
+        auto const rootHash = source->getHash();
 
-        pass();
+        // Turn the source into a fetch pack: node hash -> serialized node.
+        Map map;
+        source->visitNodes([this, &map](SHAMapTreeNode& node) {
+            Serializer s;
+            node.serializeWithPrefix(s);
+            onFetch(map, node.getHash(), s.getData());
+            return true;
+        });
 
-        //         beast::Random r;
-        //         add_random_items_ (tableItems, *t1, r);
-        //         std::shared_ptr <Table> t2 (t1->snapShot (true));
-        //
-        //         add_random_items_ (tableItemsExtra, *t1, r);
-        //         add_random_items_ (tableItemsExtra, *t2, r);
+        // Rebuild the map in a fresh family, sourcing every node from the pack
+        // through the SHAMapSyncFilter.
+        auto const rebuilt = std::make_shared<Table>(SHAMapType::FREE, rootHash.asUInt256(), f2);
+        TestFilter filter(map, journal);
+        rebuilt->setSynching();
+        BEAST_EXPECT(rebuilt->fetchRoot(rootHash, &filter));
 
-        // turn t1 into t2
-        //         Map map;
-        //         t2->getFetchPack (t1.get(), true, 1000000, std::bind (
-        //             &FetchPack_test::on_fetch, this, std::ref (map),
-        //             std::placeholders::_1, std::placeholders::_2));
-        //         t1->getFetchPack (nullptr, true, 1000000, std::bind (
-        //             &FetchPack_test::on_fetch, this, std::ref (map),
-        //             std::placeholders::_1, std::placeholders::_2));
+        // Everything should be in the pack, so no nodes should be missing.
+        BEAST_EXPECT(rebuilt->getMissingNodes(2048, &filter).empty());
+        rebuilt->clearSynching();
 
-        // try to rebuild t2 from the fetch pack
-        //         std::shared_ptr <Table> t3;
-        //         try
-        //         {
-        //             TestFilter filter (map, beast::Journal());
-        //
-        //             t3 = std::make_shared <Table> (SHAMapType::FREE,
-        //             t2->getHash (),
-        //                 fullBelowCache);
-        //
-        //             BEAST_EXPECT(t3->fetchRoot (t2->getHash (), &filter),
-        //             "unable to get root");
-        //
-        //             // everything should be in the pack, no hashes should be
-        //             needed std::vector <uint256> hashes =
-        //             t3->getNeededHashes(1, &filter);
-        //             BEAST_EXPECT(hashes.empty(), "missing hashes");
-        //
-        //             BEAST_EXPECT(t3->getHash () == t2->getHash (), "root
-        //             hashes do not match"); BEAST_EXPECT(t3->deepCompare
-        //             (*t2), "failed compare");
-        //         }
-        //         catch (std::exception const&)
-        //         {
-        //             fail ("unhandled exception");
-        //         }
+        BEAST_EXPECT(rebuilt->deepCompare(*source));
     }
 };
 

--- a/src/xrpld/app/ledger/detail/LedgerMaster.cpp
+++ b/src/xrpld/app/ledger/detail/LedgerMaster.cpp
@@ -137,7 +137,7 @@ LedgerMaster::LedgerMaster(
           std::chrono::seconds{45},
           stopwatch,
           app_.getJournal("TaggedCache"))
-    , stats_(std::bind(&LedgerMaster::collectMetrics, this), collector)
+    , stats_([this] { collectMetrics(); }, collector)
 {
 }
 

--- a/src/xrpld/app/misc/NetworkOPs.cpp
+++ b/src/xrpld/app/misc/NetworkOPs.cpp
@@ -330,7 +330,7 @@ public:
         , jobQueue_(jobQueue)
         , standalone_(standalone)
         , minPeerCount_(startValid ? 0 : minPeerCount)
-        , stats_(std::bind(&NetworkOPsImp::collectMetrics, this), collector)
+        , stats_([this] { collectMetrics(); }, collector)
     {
     }
 

--- a/src/xrpld/app/misc/SHAMapStoreImp.cpp
+++ b/src/xrpld/app/misc/SHAMapStoreImp.cpp
@@ -331,11 +331,9 @@ SHAMapStoreImp::run()
             try
             {
                 validatedLedger->stateMap().snapShot(false)->visitNodes(
-                    std::bind(
-                        &SHAMapStoreImp::copyNode,
-                        this,
-                        std::ref(nodeCount),
-                        std::placeholders::_1));
+                    [this, &nodeCount](auto&& PH1) {
+                        return copyNode(nodeCount, std::forward<decltype(PH1)>(PH1));
+                    });
             }
             catch (SHAMapMissingNode const& e)
             {

--- a/src/xrpld/app/misc/SHAMapStoreImp.cpp
+++ b/src/xrpld/app/misc/SHAMapStoreImp.cpp
@@ -331,8 +331,8 @@ SHAMapStoreImp::run()
             try
             {
                 validatedLedger->stateMap().snapShot(false)->visitNodes(
-                    [this, &nodeCount](auto&& PH1) {
-                        return copyNode(nodeCount, std::forward<decltype(PH1)>(PH1));
+                    [this, &nodeCount](auto&& pH1) {
+                        return copyNode(nodeCount, std::forward<decltype(pH1)>(pH1));
                     });
             }
             catch (SHAMapMissingNode const& e)

--- a/src/xrpld/app/misc/SHAMapStoreImp.cpp
+++ b/src/xrpld/app/misc/SHAMapStoreImp.cpp
@@ -331,8 +331,8 @@ SHAMapStoreImp::run()
             try
             {
                 validatedLedger->stateMap().snapShot(false)->visitNodes(
-                    [this, &nodeCount](auto&& pH1) {
-                        return copyNode(nodeCount, std::forward<decltype(pH1)>(pH1));
+                    [this, &nodeCount](SHAMapTreeNode const& node) {
+                        return copyNode(nodeCount, node);
                     });
             }
             catch (SHAMapMissingNode const& e)

--- a/src/xrpld/app/misc/detail/WorkBase.h
+++ b/src/xrpld/app/misc/detail/WorkBase.h
@@ -147,9 +147,9 @@ WorkBase<Impl>::run()
         host_,
         port_,
         boost::asio::bind_executor(
-            strand_, [capture0 = impl().shared_from_this()](auto&& PH1, auto&& PH2) {
+            strand_, [capture0 = impl().shared_from_this()](auto&& pH1, auto&& pH2) {
                 capture0->onResolve(
-                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             }));
 }
 
@@ -193,9 +193,9 @@ WorkBase<Impl>::onResolve(error_code const& ec, results_type results)
         socket_,
         results,
         boost::asio::bind_executor(
-            strand_, [capture0 = impl().shared_from_this()](auto&& PH1, auto&& PH2) {
+            strand_, [capture0 = impl().shared_from_this()](auto&& pH1, auto&& pH2) {
                 capture0->onConnect(
-                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             }));
 }
 
@@ -224,8 +224,8 @@ WorkBase<Impl>::onStart()
     boost::beast::http::async_write(
         impl().stream(),
         req_,
-        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-            capture0->onRequest(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+            capture0->onRequest(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -240,8 +240,8 @@ WorkBase<Impl>::onRequest(error_code const& ec)
         impl().stream(),
         readBuf_,
         res_,
-        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
-            capture0->onResponse(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
+            capture0->onResponse(std::forward<decltype(pH1)>(pH1));
         }));
 }
 

--- a/src/xrpld/app/misc/detail/WorkBase.h
+++ b/src/xrpld/app/misc/detail/WorkBase.h
@@ -138,8 +138,8 @@ WorkBase<Impl>::run()
     if (!strand_.running_in_this_thread())
     {
         return boost::asio::post(
-            ios_, boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()] {
-                capture0->run();
+            ios_, boost::asio::bind_executor(strand_, [self = impl().shared_from_this()] {
+                self->run();
             }));
     }
 
@@ -147,9 +147,9 @@ WorkBase<Impl>::run()
         host_,
         port_,
         boost::asio::bind_executor(
-            strand_, [capture0 = impl().shared_from_this()](auto&& pH1, auto&& pH2) {
-                capture0->onResolve(
-                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+            strand_,
+            [self = impl().shared_from_this()](error_code const& ec, results_type results) {
+                self->onResolve(ec, results);
             }));
 }
 
@@ -163,7 +163,7 @@ WorkBase<Impl>::cancel()
             ios_,
 
             boost::asio::bind_executor(
-                strand_, [capture0 = impl().shared_from_this()] { capture0->cancel(); }));
+                strand_, [self = impl().shared_from_this()] { self->cancel(); }));
     }
 
     error_code ec;
@@ -193,9 +193,12 @@ WorkBase<Impl>::onResolve(error_code const& ec, results_type results)
         socket_,
         results,
         boost::asio::bind_executor(
-            strand_, [capture0 = impl().shared_from_this()](auto&& pH1, auto&& pH2) {
-                capture0->onConnect(
-                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
+            strand_,
+            [self = impl().shared_from_this()](
+                error_code const& ec, endpoint_type const& endpoint) {
+                // Call the base-class overload explicitly: the derived Impl
+                // hides it with its own single-argument onConnect(ec).
+                self->WorkBase::onConnect(ec, endpoint);
             }));
 }
 
@@ -224,9 +227,10 @@ WorkBase<Impl>::onStart()
     boost::beast::http::async_write(
         impl().stream(),
         req_,
-        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-            capture0->onRequest(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_, [self = impl().shared_from_this()](error_code const& ec, std::size_t) {
+                self->onRequest(ec);
+            }));
 }
 
 template <class Impl>
@@ -240,9 +244,10 @@ WorkBase<Impl>::onRequest(error_code const& ec)
         impl().stream(),
         readBuf_,
         res_,
-        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& pH1) {
-            capture0->onResponse(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_, [self = impl().shared_from_this()](error_code const& ec, std::size_t) {
+                self->onResponse(ec);
+            }));
 }
 
 template <class Impl>

--- a/src/xrpld/app/misc/detail/WorkBase.h
+++ b/src/xrpld/app/misc/detail/WorkBase.h
@@ -12,6 +12,7 @@
 #include <boost/beast/http/read.hpp>
 #include <boost/beast/http/write.hpp>
 
+#include <cstddef>
 #include <functional>
 #include <string>
 #include <utility>

--- a/src/xrpld/app/misc/detail/WorkBase.h
+++ b/src/xrpld/app/misc/detail/WorkBase.h
@@ -138,21 +138,19 @@ WorkBase<Impl>::run()
     if (!strand_.running_in_this_thread())
     {
         return boost::asio::post(
-            ios_,
-            boost::asio::bind_executor(
-                strand_, std::bind(&WorkBase::run, impl().shared_from_this())));
+            ios_, boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()] {
+                capture0->run();
+            }));
     }
 
     resolver_.async_resolve(
         host_,
         port_,
         boost::asio::bind_executor(
-            strand_,
-            std::bind(
-                &WorkBase::onResolve,
-                impl().shared_from_this(),
-                std::placeholders::_1,
-                std::placeholders::_2)));
+            strand_, [capture0 = impl().shared_from_this()](auto&& PH1, auto&& PH2) {
+                capture0->onResolve(
+                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            }));
 }
 
 template <class Impl>
@@ -165,7 +163,7 @@ WorkBase<Impl>::cancel()
             ios_,
 
             boost::asio::bind_executor(
-                strand_, std::bind(&WorkBase::cancel, impl().shared_from_this())));
+                strand_, [capture0 = impl().shared_from_this()] { capture0->cancel(); }));
     }
 
     error_code ec;
@@ -195,12 +193,10 @@ WorkBase<Impl>::onResolve(error_code const& ec, results_type results)
         socket_,
         results,
         boost::asio::bind_executor(
-            strand_,
-            std::bind(
-                &WorkBase::onConnect,
-                impl().shared_from_this(),
-                std::placeholders::_1,
-                std::placeholders::_2)));
+            strand_, [capture0 = impl().shared_from_this()](auto&& PH1, auto&& PH2) {
+                capture0->onConnect(
+                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            }));
 }
 
 template <class Impl>
@@ -228,9 +224,9 @@ WorkBase<Impl>::onStart()
     boost::beast::http::async_write(
         impl().stream(),
         req_,
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&WorkBase::onRequest, impl().shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+            capture0->onRequest(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 template <class Impl>
@@ -244,9 +240,9 @@ WorkBase<Impl>::onRequest(error_code const& ec)
         impl().stream(),
         readBuf_,
         res_,
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&WorkBase::onResponse, impl().shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = impl().shared_from_this()](auto&& PH1) {
+            capture0->onResponse(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 template <class Impl>

--- a/src/xrpld/app/misc/detail/WorkFile.h
+++ b/src/xrpld/app/misc/detail/WorkFile.h
@@ -64,8 +64,9 @@ WorkFile::run()
     if (!strand_.running_in_this_thread())
     {
         boost::asio::post(
-            ios_,
-            boost::asio::bind_executor(strand_, std::bind(&WorkFile::run, shared_from_this())));
+            ios_, boost::asio::bind_executor(strand_, [capture0 = shared_from_this()] {
+                capture0->run();
+            }));
         return;
     }
 

--- a/src/xrpld/app/misc/detail/WorkFile.h
+++ b/src/xrpld/app/misc/detail/WorkFile.h
@@ -63,10 +63,9 @@ WorkFile::run()
 {
     if (!strand_.running_in_this_thread())
     {
-        boost::asio::post(
-            ios_, boost::asio::bind_executor(strand_, [capture0 = shared_from_this()] {
-                capture0->run();
-            }));
+        boost::asio::post(ios_, boost::asio::bind_executor(strand_, [self = shared_from_this()] {
+                              self->run();
+                          }));
         return;
     }
 

--- a/src/xrpld/app/misc/detail/WorkSSL.cpp
+++ b/src/xrpld/app/misc/detail/WorkSSL.cpp
@@ -12,7 +12,6 @@
 #include <boost/asio/ssl/stream_base.hpp>
 #include <boost/format/free_funcs.hpp>
 
-#include <functional>
 #include <stdexcept>
 #include <string>
 
@@ -54,8 +53,8 @@ WorkSSL::onConnect(error_code const& ec)
 
     stream_.async_handshake(
         boost::asio::ssl::stream_base::client,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
         }));
 }
 

--- a/src/xrpld/app/misc/detail/WorkSSL.cpp
+++ b/src/xrpld/app/misc/detail/WorkSSL.cpp
@@ -54,8 +54,9 @@ WorkSSL::onConnect(error_code const& ec)
 
     stream_.async_handshake(
         boost::asio::ssl::stream_base::client,
-        boost::asio::bind_executor(
-            strand_, std::bind(&WorkSSL::onHandshake, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 void

--- a/src/xrpld/app/misc/detail/WorkSSL.cpp
+++ b/src/xrpld/app/misc/detail/WorkSSL.cpp
@@ -53,9 +53,8 @@ WorkSSL::onConnect(error_code const& ec)
 
     stream_.async_handshake(
         boost::asio::ssl::stream_base::client,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_, [self = shared_from_this()](error_code const& ec) { self->onHandshake(ec); }));
 }
 
 void

--- a/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
+++ b/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
@@ -421,8 +421,8 @@ SQLiteDatabase::oldestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(200);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
+    auto onUnsavedLedger = [&app = registry_.get().getApp()](std::uint32_t seq) {
+        saveLedgerAsync(app, seq);
     };
     AccountTxs ret;
     auto onTransaction = [&ret, &app = registry_.get().getApp()](
@@ -452,8 +452,8 @@ SQLiteDatabase::newestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(200);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
+    auto onUnsavedLedger = [&app = registry_.get().getApp()](std::uint32_t seq) {
+        saveLedgerAsync(app, seq);
     };
     AccountTxs ret;
     auto onTransaction = [&ret, &app = registry_.get().getApp()](
@@ -483,8 +483,8 @@ SQLiteDatabase::oldestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(500);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
+    auto onUnsavedLedger = [&app = registry_.get().getApp()](std::uint32_t seq) {
+        saveLedgerAsync(app, seq);
     };
     MetaTxsList ret;
     auto onTransaction =
@@ -512,8 +512,8 @@ SQLiteDatabase::newestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(500);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
+    auto onUnsavedLedger = [&app = registry_.get().getApp()](std::uint32_t seq) {
+        saveLedgerAsync(app, seq);
     };
     MetaTxsList ret;
     auto onTransaction =

--- a/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
+++ b/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
@@ -421,8 +421,9 @@ SQLiteDatabase::oldestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(200);
-    auto onUnsavedLedger =
-        std::bind(saveLedgerAsync, std::ref(registry_.get().getApp()), std::placeholders::_1);
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    };
     AccountTxs ret;
     auto onTransaction = [&ret, &app = registry_.get().getApp()](
                              std::uint32_t ledgerIndex,
@@ -451,8 +452,9 @@ SQLiteDatabase::newestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(200);
-    auto onUnsavedLedger =
-        std::bind(saveLedgerAsync, std::ref(registry_.get().getApp()), std::placeholders::_1);
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    };
     AccountTxs ret;
     auto onTransaction = [&ret, &app = registry_.get().getApp()](
                              std::uint32_t ledgerIndex,
@@ -481,8 +483,9 @@ SQLiteDatabase::oldestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(500);
-    auto onUnsavedLedger =
-        std::bind(saveLedgerAsync, std::ref(registry_.get().getApp()), std::placeholders::_1);
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    };
     MetaTxsList ret;
     auto onTransaction =
         [&ret](
@@ -509,8 +512,9 @@ SQLiteDatabase::newestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(500);
-    auto onUnsavedLedger =
-        std::bind(saveLedgerAsync, std::ref(registry_.get().getApp()), std::placeholders::_1);
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    };
     MetaTxsList ret;
     auto onTransaction =
         [&ret](

--- a/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
+++ b/src/xrpld/app/rdb/backend/detail/SQLiteDatabase.cpp
@@ -421,8 +421,8 @@ SQLiteDatabase::oldestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(200);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
     };
     AccountTxs ret;
     auto onTransaction = [&ret, &app = registry_.get().getApp()](
@@ -452,8 +452,8 @@ SQLiteDatabase::newestAccountTxPage(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(200);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
     };
     AccountTxs ret;
     auto onTransaction = [&ret, &app = registry_.get().getApp()](
@@ -483,8 +483,8 @@ SQLiteDatabase::oldestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(500);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
     };
     MetaTxsList ret;
     auto onTransaction =
@@ -512,8 +512,8 @@ SQLiteDatabase::newestAccountTxPageB(AccountTxPageOptions const& options)
         return {};
 
     static std::uint32_t const kPageLength(500);
-    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& PH1) {
-        saveLedgerAsync(capture0, std::forward<decltype(PH1)>(PH1));
+    auto onUnsavedLedger = [&capture0 = registry_.get().getApp()](auto&& pH1) {
+        saveLedgerAsync(capture0, std::forward<decltype(pH1)>(pH1));
     };
     MetaTxsList ret;
     auto onTransaction =

--- a/src/xrpld/overlay/detail/ConnectAttempt.cpp
+++ b/src/xrpld/overlay/detail/ConnectAttempt.cpp
@@ -35,6 +35,7 @@
 #include <boost/system/system_error.hpp>
 
 #include <chrono>
+#include <cstddef>
 #include <exception>
 #include <memory>
 #include <optional>
@@ -85,7 +86,7 @@ ConnectAttempt::stop()
 {
     if (!strand_.running_in_this_thread())
     {
-        boost::asio::post(strand_, [capture0 = shared_from_this()] { capture0->stop(); });
+        boost::asio::post(strand_, [self = shared_from_this()] { self->stop(); });
         return;
     }
     if (socket_.is_open())
@@ -102,9 +103,8 @@ ConnectAttempt::run()
 
     stream_.next_layer().async_connect(
         remoteEndpoint_,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onConnect(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_, [self = shared_from_this()](error_code const& ec) { self->onConnect(ec); }));
 }
 
 //------------------------------------------------------------------------------
@@ -158,9 +158,8 @@ ConnectAttempt::setTimer()
     }
 
     timer_.async_wait(
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onTimer(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_, [self = shared_from_this()](error_code const& ec) { self->onTimer(ec); }));
 }
 
 void
@@ -226,9 +225,8 @@ ConnectAttempt::onConnect(error_code ec)
     stream_.set_verify_mode(boost::asio::ssl::verify_none);
     stream_.async_handshake(
         boost::asio::ssl::stream_base::client,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_, [self = shared_from_this()](error_code const& ec) { self->onHandshake(ec); }));
 }
 
 void
@@ -287,9 +285,9 @@ ConnectAttempt::onHandshake(error_code ec)
     boost::beast::http::async_write(
         stream_,
         req_,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onWrite(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_,
+            [self = shared_from_this()](error_code const& ec, std::size_t) { self->onWrite(ec); }));
 }
 
 void
@@ -313,9 +311,9 @@ ConnectAttempt::onWrite(error_code ec)
         stream_,
         readBuf_,
         response_,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onRead(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            strand_,
+            [self = shared_from_this()](error_code const& ec, std::size_t) { self->onRead(ec); }));
 }
 
 void
@@ -336,9 +334,9 @@ ConnectAttempt::onRead(error_code ec)
             JLOG(journal_.debug()) << "EOF";
             setTimer();
             stream_.async_shutdown(
-                boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-                    capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
-                }));
+                boost::asio::bind_executor(
+                    strand_,
+                    [self = shared_from_this()](error_code const& ec) { self->onShutdown(ec); }));
             return;
         }
 

--- a/src/xrpld/overlay/detail/ConnectAttempt.cpp
+++ b/src/xrpld/overlay/detail/ConnectAttempt.cpp
@@ -86,7 +86,7 @@ ConnectAttempt::stop()
 {
     if (!strand_.running_in_this_thread())
     {
-        boost::asio::post(strand_, std::bind(&ConnectAttempt::stop, shared_from_this()));
+        boost::asio::post(strand_, [capture0 = shared_from_this()] { capture0->stop(); });
         return;
     }
     if (socket_.is_open())
@@ -103,9 +103,9 @@ ConnectAttempt::run()
 
     stream_.next_layer().async_connect(
         remoteEndpoint_,
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&ConnectAttempt::onConnect, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onConnect(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 //------------------------------------------------------------------------------
@@ -159,9 +159,9 @@ ConnectAttempt::setTimer()
     }
 
     timer_.async_wait(
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&ConnectAttempt::onTimer, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 void
@@ -227,9 +227,9 @@ ConnectAttempt::onConnect(error_code ec)
     stream_.set_verify_mode(boost::asio::ssl::verify_none);
     stream_.async_handshake(
         boost::asio::ssl::stream_base::client,
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&ConnectAttempt::onHandshake, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 void
@@ -288,9 +288,9 @@ ConnectAttempt::onHandshake(error_code ec)
     boost::beast::http::async_write(
         stream_,
         req_,
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&ConnectAttempt::onWrite, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onWrite(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 void
@@ -314,9 +314,9 @@ ConnectAttempt::onWrite(error_code ec)
         stream_,
         readBuf_,
         response_,
-        boost::asio::bind_executor(
-            strand_,
-            std::bind(&ConnectAttempt::onRead, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onRead(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 void
@@ -337,10 +337,9 @@ ConnectAttempt::onRead(error_code ec)
             JLOG(journal_.debug()) << "EOF";
             setTimer();
             stream_.async_shutdown(
-                boost::asio::bind_executor(
-                    strand_,
-                    std::bind(
-                        &ConnectAttempt::onShutdown, shared_from_this(), std::placeholders::_1)));
+                boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+                    capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                }));
             return;
         }
 

--- a/src/xrpld/overlay/detail/ConnectAttempt.cpp
+++ b/src/xrpld/overlay/detail/ConnectAttempt.cpp
@@ -36,7 +36,6 @@
 
 #include <chrono>
 #include <exception>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -103,8 +102,8 @@ ConnectAttempt::run()
 
     stream_.next_layer().async_connect(
         remoteEndpoint_,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onConnect(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onConnect(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -159,8 +158,8 @@ ConnectAttempt::setTimer()
     }
 
     timer_.async_wait(
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onTimer(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -227,8 +226,8 @@ ConnectAttempt::onConnect(error_code ec)
     stream_.set_verify_mode(boost::asio::ssl::verify_none);
     stream_.async_handshake(
         boost::asio::ssl::stream_base::client,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onHandshake(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onHandshake(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -288,8 +287,8 @@ ConnectAttempt::onHandshake(error_code ec)
     boost::beast::http::async_write(
         stream_,
         req_,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onWrite(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onWrite(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -314,8 +313,8 @@ ConnectAttempt::onWrite(error_code ec)
         stream_,
         readBuf_,
         response_,
-        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onRead(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onRead(std::forward<decltype(pH1)>(pH1));
         }));
 }
 
@@ -337,8 +336,8 @@ ConnectAttempt::onRead(error_code ec)
             JLOG(journal_.debug()) << "EOF";
             setTimer();
             stream_.async_shutdown(
-                boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-                    capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+                boost::asio::bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+                    capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
                 }));
             return;
         }

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -131,8 +131,8 @@ OverlayImpl::Timer::asyncWait()
 {
     timer.expires_after(std::chrono::seconds(1));
     timer.async_wait(
-        boost::asio::bind_executor(overlay_.strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+        boost::asio::bind_executor(overlay_.strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onTimer(std::forward<decltype(pH1)>(pH1));
         }));
 }
 

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -131,9 +131,9 @@ OverlayImpl::Timer::asyncWait()
 {
     timer.expires_after(std::chrono::seconds(1));
     timer.async_wait(
-        boost::asio::bind_executor(
-            overlay_.strand_,
-            std::bind(&Timer::onTimer, shared_from_this(), std::placeholders::_1)));
+        boost::asio::bind_executor(overlay_.strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+        }));
 }
 
 void
@@ -190,7 +190,7 @@ OverlayImpl::OverlayImpl(
     , nextId_(1)
     , slots_(app, *this, app.config())
     , stats_(
-          std::bind(&OverlayImpl::collectMetrics, this),
+          [this] { collectMetrics(); },
           collector,
           [counts = traffic_.getCounts(), collector]() {
               std::unordered_map<TrafficCount::Category, TrafficGauges> ret;
@@ -593,7 +593,7 @@ OverlayImpl::start()
 void
 OverlayImpl::stop()
 {
-    boost::asio::dispatch(strand_, std::bind(&OverlayImpl::stopChildren, this));
+    boost::asio::dispatch(strand_, [this] { stopChildren(); });
     {
         std::unique_lock<decltype(mutex_)> lock(mutex_);
         cond_.wait(lock, [this] { return list_.empty(); });
@@ -1490,7 +1490,7 @@ OverlayImpl::deletePeer(Peer::id_t id)
 {
     if (!strand_.running_in_this_thread())
     {
-        post(strand_, std::bind(&OverlayImpl::deletePeer, this, id));
+        post(strand_, [this, id] { deletePeer(id); });
         return;
     }
 
@@ -1502,7 +1502,7 @@ OverlayImpl::deleteIdlePeers()
 {
     if (!strand_.running_in_this_thread())
     {
-        post(strand_, std::bind(&OverlayImpl::deleteIdlePeers, this));
+        post(strand_, [this] { deleteIdlePeers(); });
         return;
     }
 

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -131,9 +131,9 @@ OverlayImpl::Timer::asyncWait()
 {
     timer.expires_after(std::chrono::seconds(1));
     timer.async_wait(
-        boost::asio::bind_executor(overlay_.strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onTimer(std::forward<decltype(pH1)>(pH1));
-        }));
+        boost::asio::bind_executor(
+            overlay_.strand_,
+            [self = shared_from_this()](error_code const& ec) { self->onTimer(ec); }));
 }
 
 void

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -427,7 +427,7 @@ public:
     addTxMetrics(Args... args)
     {
         if (!strand_.running_in_this_thread())
-            return post(strand_, std::bind(&OverlayImpl::addTxMetrics<Args...>, this, args...));
+            return post(strand_, [this, args] { addTxMetrics(args, args); });
 
         txMetrics_.addMetrics(args...);
     }

--- a/src/xrpld/overlay/detail/OverlayImpl.h
+++ b/src/xrpld/overlay/detail/OverlayImpl.h
@@ -427,7 +427,7 @@ public:
     addTxMetrics(Args... args)
     {
         if (!strand_.running_in_this_thread())
-            return post(strand_, [this, args] { addTxMetrics(args, args); });
+            return post(strand_, [this, args...] { addTxMetrics(args...); });
 
         txMetrics_.addMetrics(args...);
     }

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -320,10 +320,10 @@ PeerImp::send(std::shared_ptr<Message> const& m)
         boost::asio::async_write(
             self->stream_,
             boost::asio::buffer(self->sendQueue_.front()->getBuffer(self->compressionEnabled_)),
-            bind_executor(
-                self->strand_,
-                std::bind(
-                    &PeerImp::onWriteMessage, self, std::placeholders::_1, std::placeholders::_2)));
+            bind_executor(self->strand_, [self](auto&& PH1, auto&& PH2) {
+                self->onWriteMessage(
+                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            }));
     });
 }
 
@@ -649,8 +649,9 @@ PeerImp::gracefulClose()
     if (!sendQueue_.empty())
         return;
     setTimer();
-    stream_.async_shutdown(bind_executor(
-        strand_, std::bind(&PeerImp::onShutdown, shared_from_this(), std::placeholders::_1)));
+    stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+        capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+    }));
 }
 
 void
@@ -665,8 +666,9 @@ PeerImp::setTimer()
         JLOG(journal_.error()) << "setTimer: " << e.code();
         return;
     }
-    timer_.async_wait(bind_executor(
-        strand_, std::bind(&PeerImp::onTimer, shared_from_this(), std::placeholders::_1)));
+    timer_.async_wait(bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+        capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+    }));
 }
 
 // convenience for ignoring the error code
@@ -973,13 +975,10 @@ PeerImp::onReadMessage(error_code ec, std::size_t bytesTransferred)
     // Timeout on writes only
     stream_.async_read_some(
         readBuffer_.prepare(std::max(Tuning::kReadBufferBytes, hint)),
-        bind_executor(
-            strand_,
-            std::bind(
-                &PeerImp::onReadMessage,
-                shared_from_this(),
-                std::placeholders::_1,
-                std::placeholders::_2)));
+        bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+            capture0->onReadMessage(
+                std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+        }));
 }
 
 void
@@ -1012,20 +1011,18 @@ PeerImp::onWriteMessage(error_code ec, std::size_t bytesTransferred)
         boost::asio::async_write(
             stream_,
             boost::asio::buffer(sendQueue_.front()->getBuffer(compressionEnabled_)),
-            bind_executor(
-                strand_,
-                std::bind(
-                    &PeerImp::onWriteMessage,
-                    shared_from_this(),
-                    std::placeholders::_1,
-                    std::placeholders::_2)));
+            bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+                capture0->onWriteMessage(
+                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+            }));
         return;
     }
 
     if (gracefulClose_)
     {
-        stream_.async_shutdown(bind_executor(
-            strand_, std::bind(&PeerImp::onShutdown, shared_from_this(), std::placeholders::_1)));
+        stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
+            capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+        }));
         return;
     }
 }

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -320,9 +320,9 @@ PeerImp::send(std::shared_ptr<Message> const& m)
         boost::asio::async_write(
             self->stream_,
             boost::asio::buffer(self->sendQueue_.front()->getBuffer(self->compressionEnabled_)),
-            bind_executor(self->strand_, [self](auto&& PH1, auto&& PH2) {
+            bind_executor(self->strand_, [self](auto&& pH1, auto&& pH2) {
                 self->onWriteMessage(
-                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             }));
     });
 }
@@ -649,8 +649,8 @@ PeerImp::gracefulClose()
     if (!sendQueue_.empty())
         return;
     setTimer();
-    stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-        capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+    stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+        capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
     }));
 }
 
@@ -666,8 +666,8 @@ PeerImp::setTimer()
         JLOG(journal_.error()) << "setTimer: " << e.code();
         return;
     }
-    timer_.async_wait(bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-        capture0->onTimer(std::forward<decltype(PH1)>(PH1));
+    timer_.async_wait(bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+        capture0->onTimer(std::forward<decltype(pH1)>(pH1));
     }));
 }
 
@@ -975,9 +975,9 @@ PeerImp::onReadMessage(error_code ec, std::size_t bytesTransferred)
     // Timeout on writes only
     stream_.async_read_some(
         readBuffer_.prepare(std::max(Tuning::kReadBufferBytes, hint)),
-        bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+        bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
             capture0->onReadMessage(
-                std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
         }));
 }
 
@@ -1011,17 +1011,17 @@ PeerImp::onWriteMessage(error_code ec, std::size_t bytesTransferred)
         boost::asio::async_write(
             stream_,
             boost::asio::buffer(sendQueue_.front()->getBuffer(compressionEnabled_)),
-            bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1, auto&& PH2) {
+            bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
                 capture0->onWriteMessage(
-                    std::forward<decltype(PH1)>(PH1), std::forward<decltype(PH2)>(PH2));
+                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
             }));
         return;
     }
 
     if (gracefulClose_)
     {
-        stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& PH1) {
-            capture0->onShutdown(std::forward<decltype(PH1)>(PH1));
+        stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
+            capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
         }));
         return;
     }

--- a/src/xrpld/overlay/detail/PeerImp.cpp
+++ b/src/xrpld/overlay/detail/PeerImp.cpp
@@ -320,10 +320,10 @@ PeerImp::send(std::shared_ptr<Message> const& m)
         boost::asio::async_write(
             self->stream_,
             boost::asio::buffer(self->sendQueue_.front()->getBuffer(self->compressionEnabled_)),
-            bind_executor(self->strand_, [self](auto&& pH1, auto&& pH2) {
-                self->onWriteMessage(
-                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-            }));
+            bind_executor(
+                self->strand_, [self](error_code const& ec, std::size_t bytesTransferred) {
+                    self->onWriteMessage(ec, bytesTransferred);
+                }));
     });
 }
 
@@ -649,9 +649,8 @@ PeerImp::gracefulClose()
     if (!sendQueue_.empty())
         return;
     setTimer();
-    stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-        capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
-    }));
+    stream_.async_shutdown(bind_executor(
+        strand_, [self = shared_from_this()](error_code const& ec) { self->onShutdown(ec); }));
 }
 
 void
@@ -666,9 +665,8 @@ PeerImp::setTimer()
         JLOG(journal_.error()) << "setTimer: " << e.code();
         return;
     }
-    timer_.async_wait(bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-        capture0->onTimer(std::forward<decltype(pH1)>(pH1));
-    }));
+    timer_.async_wait(bind_executor(
+        strand_, [self = shared_from_this()](error_code const& ec) { self->onTimer(ec); }));
 }
 
 // convenience for ignoring the error code
@@ -975,10 +973,11 @@ PeerImp::onReadMessage(error_code ec, std::size_t bytesTransferred)
     // Timeout on writes only
     stream_.async_read_some(
         readBuffer_.prepare(std::max(Tuning::kReadBufferBytes, hint)),
-        bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-            capture0->onReadMessage(
-                std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-        }));
+        bind_executor(
+            strand_,
+            [self = shared_from_this()](error_code const& ec, std::size_t bytesTransferred) {
+                self->onReadMessage(ec, bytesTransferred);
+            }));
 }
 
 void
@@ -1011,18 +1010,18 @@ PeerImp::onWriteMessage(error_code ec, std::size_t bytesTransferred)
         boost::asio::async_write(
             stream_,
             boost::asio::buffer(sendQueue_.front()->getBuffer(compressionEnabled_)),
-            bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1, auto&& pH2) {
-                capture0->onWriteMessage(
-                    std::forward<decltype(pH1)>(pH1), std::forward<decltype(pH2)>(pH2));
-            }));
+            bind_executor(
+                strand_,
+                [self = shared_from_this()](error_code const& ec, std::size_t bytesTransferred) {
+                    self->onWriteMessage(ec, bytesTransferred);
+                }));
         return;
     }
 
     if (gracefulClose_)
     {
-        stream_.async_shutdown(bind_executor(strand_, [capture0 = shared_from_this()](auto&& pH1) {
-            capture0->onShutdown(std::forward<decltype(pH1)>(pH1));
-        }));
+        stream_.async_shutdown(bind_executor(
+            strand_, [self = shared_from_this()](error_code const& ec) { self->onShutdown(ec); }));
         return;
     }
 }

--- a/src/xrpld/peerfinder/detail/Checker.h
+++ b/src/xrpld/peerfinder/detail/Checker.h
@@ -183,7 +183,7 @@ Checker<Protocol>::asyncConnect(beast::IP::Endpoint const& endpoint, Handler&& h
     }
     op->socket.async_connect(
         beast::IPAddressConversion::toAsioEndpoint(endpoint),
-        std::bind(&BasicAsyncOp::operator(), op, std::placeholders::_1));
+        [op](auto&& PH1) { (*op)(std::forward<decltype(PH1)>(PH1)); });
 }
 
 template <class Protocol>

--- a/src/xrpld/peerfinder/detail/Checker.h
+++ b/src/xrpld/peerfinder/detail/Checker.h
@@ -8,7 +8,6 @@
 #include <boost/intrusive/list.hpp>
 
 #include <condition_variable>
-#include <functional>
 #include <memory>
 #include <mutex>
 
@@ -183,7 +182,7 @@ Checker<Protocol>::asyncConnect(beast::IP::Endpoint const& endpoint, Handler&& h
     }
     op->socket.async_connect(
         beast::IPAddressConversion::toAsioEndpoint(endpoint),
-        [op](auto&& PH1) { (*op)(std::forward<decltype(PH1)>(PH1)); });
+        [op](auto&& pH1) { (*op)(std::forward<decltype(pH1)>(pH1)); });
 }
 
 template <class Protocol>

--- a/src/xrpld/peerfinder/detail/Checker.h
+++ b/src/xrpld/peerfinder/detail/Checker.h
@@ -182,7 +182,7 @@ Checker<Protocol>::asyncConnect(beast::IP::Endpoint const& endpoint, Handler&& h
     }
     op->socket.async_connect(
         beast::IPAddressConversion::toAsioEndpoint(endpoint),
-        [op](auto&& pH1) { (*op)(std::forward<decltype(pH1)>(pH1)); });
+        [op](error_code const& ec) { (*op)(ec); });
 }
 
 template <class Protocol>

--- a/src/xrpld/peerfinder/detail/Logic.h
+++ b/src/xrpld/peerfinder/detail/Logic.h
@@ -802,12 +802,10 @@ public:
                     //
                     checker.asyncConnect(
                         ep.address,
-                        std::bind(
-                            &Logic::checkComplete,
-                            this,
-                            slot->remoteEndpoint(),
-                            ep.address,
-                            std::placeholders::_1));
+                        [this, capture0 = slot->remoteEndpoint(), capture1 = ep.address](
+                            auto&& PH1) {
+                            checkComplete(capture0, capture1, std::forward<decltype(PH1)>(PH1));
+                        });
 
                     // Note that we simply discard the first Endpoint
                     // that the neighbor sends when we perform the

--- a/src/xrpld/peerfinder/detail/Logic.h
+++ b/src/xrpld/peerfinder/detail/Logic.h
@@ -803,8 +803,8 @@ public:
                     checker.asyncConnect(
                         ep.address,
                         [this, capture0 = slot->remoteEndpoint(), capture1 = ep.address](
-                            auto&& PH1) {
-                            checkComplete(capture0, capture1, std::forward<decltype(PH1)>(PH1));
+                            auto&& pH1) {
+                            checkComplete(capture0, capture1, std::forward<decltype(pH1)>(pH1));
                         });
 
                     // Note that we simply discard the first Endpoint

--- a/src/xrpld/peerfinder/detail/Logic.h
+++ b/src/xrpld/peerfinder/detail/Logic.h
@@ -802,9 +802,9 @@ public:
                     //
                     checker.asyncConnect(
                         ep.address,
-                        [this, capture0 = slot->remoteEndpoint(), capture1 = ep.address](
-                            auto&& pH1) {
-                            checkComplete(capture0, capture1, std::forward<decltype(pH1)>(pH1));
+                        [this, remoteAddress = slot->remoteEndpoint(), checkedAddress = ep.address](
+                            boost::system::error_code const& ec) {
+                            checkComplete(remoteAddress, checkedAddress, ec);
                         });
 
                     // Note that we simply discard the first Endpoint

--- a/src/xrpld/peerfinder/detail/PeerfinderManager.cpp
+++ b/src/xrpld/peerfinder/detail/PeerfinderManager.cpp
@@ -20,7 +20,6 @@
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
 
-#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/src/xrpld/peerfinder/detail/PeerfinderManager.cpp
+++ b/src/xrpld/peerfinder/detail/PeerfinderManager.cpp
@@ -61,7 +61,7 @@ public:
         , checker_(io_context_)
         , logic_(clock, store_, checker_, journal)
         , config_(config)
-        , stats_(std::bind(&ManagerImp::collectMetrics, this), collector)
+        , stats_([this] { collectMetrics(); }, collector)
     {
     }
 

--- a/src/xrpld/rpc/detail/Pathfinder.cpp
+++ b/src/xrpld/rpc/detail/Pathfinder.cpp
@@ -1157,12 +1157,12 @@ Pathfinder::addLink(
                 if (!candidates.empty())
                 {
                     std::ranges::sort(
-                        candidates,
-                        std::bind(
-                            compareAccountCandidate,
-                            ledger_->seq(),
-                            std::placeholders::_1,
-                            std::placeholders::_2));
+                        candidates, [capture0 = ledger_->seq()](auto&& PH1, auto&& PH2) {
+                            return compareAccountCandidate(
+                                capture0,
+                                std::forward<decltype(PH1)>(PH1),
+                                std::forward<decltype(PH2)>(PH2));
+                        });
 
                     int count = candidates.size();
                     // allow more paths from source

--- a/src/xrpld/rpc/detail/Pathfinder.cpp
+++ b/src/xrpld/rpc/detail/Pathfinder.cpp
@@ -1157,11 +1157,10 @@ Pathfinder::addLink(
                 if (!candidates.empty())
                 {
                     std::ranges::sort(
-                        candidates, [capture0 = ledger_->seq()](auto&& pH1, auto&& pH2) {
-                            return compareAccountCandidate(
-                                capture0,
-                                std::forward<decltype(pH1)>(pH1),
-                                std::forward<decltype(pH2)>(pH2));
+                        candidates,
+                        [seq = ledger_->seq()](
+                            AccountCandidate const& first, AccountCandidate const& second) {
+                            return compareAccountCandidate(seq, first, second);
                         });
 
                     int count = candidates.size();

--- a/src/xrpld/rpc/detail/Pathfinder.cpp
+++ b/src/xrpld/rpc/detail/Pathfinder.cpp
@@ -1157,11 +1157,11 @@ Pathfinder::addLink(
                 if (!candidates.empty())
                 {
                     std::ranges::sort(
-                        candidates, [capture0 = ledger_->seq()](auto&& PH1, auto&& PH2) {
+                        candidates, [capture0 = ledger_->seq()](auto&& pH1, auto&& pH2) {
                             return compareAccountCandidate(
                                 capture0,
-                                std::forward<decltype(PH1)>(PH1),
-                                std::forward<decltype(PH2)>(PH2));
+                                std::forward<decltype(pH1)>(pH1),
+                                std::forward<decltype(pH2)>(pH2));
                         });
 
                     int count = candidates.size();

--- a/src/xrpld/rpc/detail/RPCCall.cpp
+++ b/src/xrpld/rpc/detail/RPCCall.cpp
@@ -1745,8 +1745,8 @@ rpcClient(
                     static_cast<int>(setup.client.secure) != 0,  // Use SSL
                     config.quiet(),
                     logs,
-                    [capture0 = &jvOutput](auto&& PH1) {
-                        RPCCallImp::callRPCHandler(capture0, std::forward<decltype(PH1)>(PH1));
+                    [capture0 = &jvOutput](auto&& pH1) {
+                        RPCCallImp::callRPCHandler(capture0, std::forward<decltype(pH1)>(pH1));
                     },
                     headers);
                 isService.run();  // This blocks until there are no more
@@ -1872,24 +1872,24 @@ fromNetwork(
         ioContext,
         strIp,
         iPort,
-        [strMethod, jvParams, headers, strPath, j](auto&& PH1, auto&& PH2) {
+        [strMethod, jvParams, headers, strPath, j](auto&& pH1, auto&& pH2) {
             RPCCallImp::onRequest(
                 strMethod,
                 jvParams,
                 headers,
                 strPath,
-                std::forward<decltype(PH1)>(PH1),
-                std::forward<decltype(PH2)>(PH2),
+                std::forward<decltype(pH1)>(pH1),
+                std::forward<decltype(pH2)>(pH2),
                 j);
         },
         kRpcReplyMaxBytes,
         kRpcWebhookTimeout,
-        [callbackFuncP, j](auto&& PH1, auto&& PH2, auto&& PH3) {
+        [callbackFuncP, j](auto&& pH1, auto&& pH2, auto&& pH3) {
             return RPCCallImp::onResponse(
                 callbackFuncP,
-                std::forward<decltype(PH1)>(PH1),
-                std::forward<decltype(PH2)>(PH2),
-                std::forward<decltype(PH3)>(PH3),
+                std::forward<decltype(pH1)>(pH1),
+                std::forward<decltype(pH2)>(pH2),
+                std::forward<decltype(pH3)>(pH3),
                 j);
         },
         j);

--- a/src/xrpld/rpc/detail/RPCCall.cpp
+++ b/src/xrpld/rpc/detail/RPCCall.cpp
@@ -1745,8 +1745,8 @@ rpcClient(
                     static_cast<int>(setup.client.secure) != 0,  // Use SSL
                     config.quiet(),
                     logs,
-                    [capture0 = &jvOutput](auto&& pH1) {
-                        RPCCallImp::callRPCHandler(capture0, std::forward<decltype(pH1)>(pH1));
+                    [&jvOutput](json::Value const& jvInput) {
+                        RPCCallImp::callRPCHandler(&jvOutput, jvInput);
                     },
                     headers);
                 isService.run();  // This blocks until there are no more
@@ -1872,25 +1872,15 @@ fromNetwork(
         ioContext,
         strIp,
         iPort,
-        [strMethod, jvParams, headers, strPath, j](auto&& pH1, auto&& pH2) {
-            RPCCallImp::onRequest(
-                strMethod,
-                jvParams,
-                headers,
-                strPath,
-                std::forward<decltype(pH1)>(pH1),
-                std::forward<decltype(pH2)>(pH2),
-                j);
+        [strMethod, jvParams, headers, strPath, j](
+            boost::asio::streambuf& sb, std::string const& strHost) {
+            RPCCallImp::onRequest(strMethod, jvParams, headers, strPath, sb, strHost, j);
         },
         kRpcReplyMaxBytes,
         kRpcWebhookTimeout,
-        [callbackFuncP, j](auto&& pH1, auto&& pH2, auto&& pH3) {
-            return RPCCallImp::onResponse(
-                callbackFuncP,
-                std::forward<decltype(pH1)>(pH1),
-                std::forward<decltype(pH2)>(pH2),
-                std::forward<decltype(pH3)>(pH3),
-                j);
+        [callbackFuncP, j](
+            boost::system::error_code const& ecResult, int iStatus, std::string const& strData) {
+            return RPCCallImp::onResponse(callbackFuncP, ecResult, iStatus, strData, j);
         },
         j);
 }

--- a/src/xrpld/rpc/detail/RPCCall.cpp
+++ b/src/xrpld/rpc/detail/RPCCall.cpp
@@ -1745,7 +1745,9 @@ rpcClient(
                     static_cast<int>(setup.client.secure) != 0,  // Use SSL
                     config.quiet(),
                     logs,
-                    std::bind(RPCCallImp::callRPCHandler, &jvOutput, std::placeholders::_1),
+                    [capture0 = &jvOutput](auto&& PH1) {
+                        RPCCallImp::callRPCHandler(capture0, std::forward<decltype(PH1)>(PH1));
+                    },
                     headers);
                 isService.run();  // This blocks until there are no more
                                   // outstanding async calls.
@@ -1870,24 +1872,26 @@ fromNetwork(
         ioContext,
         strIp,
         iPort,
-        std::bind(
-            &RPCCallImp::onRequest,
-            strMethod,
-            jvParams,
-            headers,
-            strPath,
-            std::placeholders::_1,
-            std::placeholders::_2,
-            j),
+        [strMethod, jvParams, headers, strPath, j](auto&& PH1, auto&& PH2) {
+            RPCCallImp::onRequest(
+                strMethod,
+                jvParams,
+                headers,
+                strPath,
+                std::forward<decltype(PH1)>(PH1),
+                std::forward<decltype(PH2)>(PH2),
+                j);
+        },
         kRpcReplyMaxBytes,
         kRpcWebhookTimeout,
-        std::bind(
-            &RPCCallImp::onResponse,
-            callbackFuncP,
-            std::placeholders::_1,
-            std::placeholders::_2,
-            std::placeholders::_3,
-            j),
+        [callbackFuncP, j](auto&& PH1, auto&& PH2, auto&& PH3) {
+            return RPCCallImp::onResponse(
+                callbackFuncP,
+                std::forward<decltype(PH1)>(PH1),
+                std::forward<decltype(PH2)>(PH2),
+                std::forward<decltype(PH3)>(PH3),
+                j);
+        },
         j);
 }
 


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

- Enabled `modernize-avoid-bind`** clang-tidy check (dropped its suppression in `.clang-tidy`).
- **Replaced all `std::bind`/`std::bind_front` with lambdas** across the codebase, using concrete parameter types/names (from the callee/asio-handler signatures) instead of the auto-fix's `auto&& pH1` placeholders; removed now-unused `<functional>` includes.
- **Fixed bugs the auto-fix introduced** — broken variadic-template pack captures (`thread.h`, `OverlayImpl.h`), wrong async completion-handler arity (`BaseWSPeer`/`WorkBase`/`HTTPClient`/`ConnectAttempt`/…), a base-class name-hiding call (`WorkBase::onConnect`), and an incompatible lambda ternary (`Logic_test`).
- **Revived the dead `FetchPack_test`** into a working, enabled test covering the `SHAMapSyncFilter`-based fetch-pack round trip.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
