### PR TITLE
refactor: Rename `checkInsufficientReserve` to `checkReserve`

### DIFF
--- a/include/xrpl/ledger/helpers/AccountRootHelpers.h
+++ b/include/xrpl/ledger/helpers/AccountRootHelpers.h
@@ -84,7 +84,7 @@ accountReserve(ReadView const& view, AccountID const& id, beast::Journal j, Adju
     return accountReserve(view, view.read(keylet::account(id)), j, adj);
 }
 
-/** Check if an account has insufficient reserve.
+/** Check if an account has sufficient reserve.
  *
  *  @param view The ledger view to read from
  *  @param tx The transaction being processed
@@ -97,7 +97,7 @@ accountReserve(ReadView const& view, AccountID const& id, beast::Journal j, Adju
  *  @return Transaction result code
  */
 [[nodiscard]] TER
-checkInsufficientReserve(
+checkReserve(
     ApplyViewContext ctx,
     SLE::const_ref accSle,
     STAmount const& accBalance,

--- a/include/xrpl/ledger/helpers/EscrowHelpers.h
+++ b/include/xrpl/ledger/helpers/EscrowHelpers.h
@@ -72,7 +72,7 @@ escrowUnlockApplyHelper<Issue>(
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
 
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx, sleDest, xrpBalance, *sponsorSle, {.ownerCountDelta = 1}, journal);
             !isTesSuccess(ret))
         {
@@ -201,7 +201,7 @@ escrowUnlockApplyHelper<MPTIssue>(
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
 
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx, sleDest, xrpBalance, *sponsorSle, {.ownerCountDelta = 1}, journal);
             !isTesSuccess(ret))
             return ret;

--- a/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/AccountRootHelpers.cpp
@@ -329,7 +329,7 @@ accountReserve(ReadView const& view, SLE::const_ref sle, beast::Journal j, Adjus
 }
 
 TER
-checkInsufficientReserve(
+checkReserve(
     ApplyViewContext ctx,
     SLE::const_ref accSle,
     STAmount const& accBalance,

--- a/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/MPTokenHelpers.cpp
@@ -210,7 +210,7 @@ authorizeMPToken(
         // budget), so this check always runs for sponsored transactions.
         if (sponsorSle || ownerCount(sleAcct, journal) >= 2)
         {
-            if (auto const ret = checkInsufficientReserve(
+            if (auto const ret = checkReserve(
                     ctx, sleAcct, priorBalance, sponsorSle, {.ownerCountDelta = 1}, journal);
                 !isTesSuccess(ret))
                 return ret;

--- a/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
+++ b/src/libxrpl/ledger/helpers/RippleStateHelpers.cpp
@@ -674,8 +674,8 @@ addEmptyHolding(
     }
 
     // Can the account cover the trust line reserve ?
-    if (auto const ret = checkInsufficientReserve(
-            ctx, sleDst, priorBalance, sponsorSle, {.ownerCountDelta = 1}, journal);
+    if (auto const ret =
+            checkReserve(ctx, sleDst, priorBalance, sponsorSle, {.ownerCountDelta = 1}, journal);
         !isTesSuccess(ret))
         return tecNO_LINE_INSUF_RESERVE;
 

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp
@@ -225,7 +225,7 @@ SponsorshipSet::doApply()
         if (hasPositiveFeeAmount)
             sponsorBalanceAfterFee -= *feeAmount;
 
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx_.getApplyViewContext(),
                 sponsorAccSle,
                 sponsorBalanceAfterFee.xrp(),
@@ -292,7 +292,7 @@ SponsorshipSet::doApply()
             STAmount sponsorBalanceAfterFee = (*sponsorAccSle)[sfBalance];
             sponsorBalanceAfterFee -= feeAmountDelta;
 
-            if (auto const ret = checkInsufficientReserve(
+            if (auto const ret = checkReserve(
                     ctx_.getApplyViewContext(),
                     sponsorAccSle,
                     sponsorBalanceAfterFee.xrp(),

--- a/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
+++ b/src/libxrpl/tx/transactors/Sponsor/SponsorshipTransfer.cpp
@@ -344,7 +344,7 @@ SponsorshipTransfer::doApply()
 
             // check new sponsor have sufficient balance
             // NOLINTNEXTLINE(readability-suspicious-call-argument)
-            if (auto const ter = checkInsufficientReserve(
+            if (auto const ter = checkReserve(
                     ctx_.getApplyViewContext(),
                     sponseeSle,
                     sponseeSle->getFieldAmount(sfBalance),
@@ -397,7 +397,7 @@ SponsorshipTransfer::doApply()
 
             // check new sponsor have sufficient balance
             // NOLINTNEXTLINE(readability-suspicious-call-argument)
-            if (auto const ter = checkInsufficientReserve(
+            if (auto const ter = checkReserve(
                     ctx_.getApplyViewContext(),
                     sponseeSle,
                     sponseeSle->getFieldAmount(sfBalance),
@@ -445,7 +445,7 @@ SponsorshipTransfer::doApply()
 
             // The owner takes the reserve burden back when the object is
             // no longer sponsored.
-            if (auto const ter = checkInsufficientReserve(
+            if (auto const ter = checkReserve(
                     ctx_.getApplyViewContext(),
                     ownerSle,
                     balanceBeforeFee(ownerSle),
@@ -485,7 +485,7 @@ SponsorshipTransfer::doApply()
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
-            if (auto const ter = checkInsufficientReserve(
+            if (auto const ter = checkReserve(
                     ctx_.getApplyViewContext(),
                     sponseeSle,
                     sponseeSle->getFieldAmount(sfBalance),
@@ -513,7 +513,7 @@ SponsorshipTransfer::doApply()
             if (!newSponsorSle)
                 return tefINTERNAL;  // LCOV_EXCL_LINE
 
-            if (auto const ter = checkInsufficientReserve(
+            if (auto const ter = checkReserve(
                     ctx_.getApplyViewContext(),
                     sponseeSle,
                     sponseeSle->getFieldAmount(sfBalance),
@@ -549,7 +549,7 @@ SponsorshipTransfer::doApply()
 
             // The sponsee must be able to hold its own account reserve after
             // the sponsorship is removed.
-            if (auto const ter = checkInsufficientReserve(
+            if (auto const ter = checkReserve(
                     ctx_.getApplyViewContext(),
                     sponseeSle,
                     balanceBeforeFee(sponseeSle),

--- a/src/libxrpl/tx/transactors/account/SignerListSet.cpp
+++ b/src/libxrpl/tx/transactors/account/SignerListSet.cpp
@@ -322,7 +322,7 @@ SignerListSet::replaceSignerList()
     auto const sponsorSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE
-    if (auto const ret = checkInsufficientReserve(
+    if (auto const ret = checkReserve(
             ctx_.getApplyViewContext(),
             sle,
             preFeeBalance_,

--- a/src/libxrpl/tx/transactors/check/CheckCash.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCash.cpp
@@ -400,7 +400,7 @@ CheckCash::doApply()
                 auto sleDst = psb.peek(keylet::account(accountID_));
 
                 // Can the account cover the trust line's or MPT reserve?
-                if (auto const ret = checkInsufficientReserve(
+                if (auto const ret = checkReserve(
                         applyViewContext,
                         sleDst,
                         preFeeBalance_,

--- a/src/libxrpl/tx/transactors/check/CheckCash.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCash.cpp
@@ -396,7 +396,7 @@ CheckCash::doApply()
 
             // Check reserve. Return destination account SLE if enough reserve,
             // otherwise return nullptr.
-            auto checkReserve = [&]() -> SLE::pointer {
+            auto checkDstReserve = [&]() -> SLE::pointer {
                 auto sleDst = psb.peek(keylet::account(accountID_));
 
                 // Can the account cover the trust line's or MPT reserve?
@@ -441,7 +441,7 @@ CheckCash::doApply()
                         //     a. this (destination) account and
                         //     b. issuing account (not sending account).
 
-                        auto const sleDst = checkReserve();
+                        auto const sleDst = checkDstReserve();
                         if (sleDst == nullptr)
                             return tecNO_LINE_INSUF_RESERVE;
 
@@ -507,7 +507,7 @@ CheckCash::doApply()
                         auto const mptokenKey = keylet::mptoken(mptID, accountID_);
                         if (!psb.exists(mptokenKey))
                         {
-                            auto sleDst = checkReserve();
+                            auto sleDst = checkDstReserve();
                             if (sleDst == nullptr)
                                 return tecINSUFFICIENT_RESERVE;
 

--- a/src/libxrpl/tx/transactors/check/CheckCreate.cpp
+++ b/src/libxrpl/tx/transactors/check/CheckCreate.cpp
@@ -198,7 +198,7 @@ CheckCreate::doApply()
     auto const sponsorSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE
-    if (auto const ret = checkInsufficientReserve(
+    if (auto const ret = checkReserve(
             ctx_.getApplyViewContext(),
             sle,
             preFeeBalance_,

--- a/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
+++ b/src/libxrpl/tx/transactors/delegate/DelegateSet.cpp
@@ -102,7 +102,7 @@ DelegateSet::doApply()
     auto const sponsorSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!sponsorSle)
         return sponsorSle.error();  // LCOV_EXCL_LINE
-    if (auto const ret = checkInsufficientReserve(
+    if (auto const ret = checkReserve(
             ctx_.getApplyViewContext(),
             sleOwner,
             preFeeBalance_,

--- a/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
+++ b/src/libxrpl/tx/transactors/escrow/EscrowCreate.cpp
@@ -445,7 +445,7 @@ EscrowCreate::doApply()
     // validates the sponsor's reserve + remaining credit. When
     // unsponsored this hits the source branch and validates the
     // source's pre-lock balance against base + (currentOC+1)*increment.
-    if (auto const ret = checkInsufficientReserve(
+    if (auto const ret = checkReserve(
             ctx_.getApplyViewContext(), sle, balance, *sponsorSle, {.ownerCountDelta = 1}, j_);
         !isTesSuccess(ret))
         return ret;
@@ -462,7 +462,7 @@ EscrowCreate::doApply()
         //                so the source only owes its base reserve.
         // - unsponsored: adj=1  — source owes base + the new increment.
         std::int32_t const ownerCountAdj = *sponsorSle ? 0 : 1;
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx_.getApplyViewContext(),
                 sle,
                 balance - STAmount(amount).xrp(),

--- a/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
+++ b/src/libxrpl/tx/transactors/payment/DepositPreauth.cpp
@@ -165,7 +165,7 @@ DepositPreauth::doApply()
         auto const sponsorSle = getTxReserveSponsor(applyViewContext);
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 applyViewContext,
                 sleOwner,
                 preFeeBalance_,
@@ -218,7 +218,7 @@ DepositPreauth::doApply()
         auto const sponsorSle = getTxReserveSponsor(applyViewContext);
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 applyViewContext,
                 sleOwner,
                 preFeeBalance_,

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelCreate.cpp
@@ -146,7 +146,7 @@ PaymentChannelCreate::doApply()
         // validates the sponsor's reserve + remaining credit. When
         // unsponsored this hits the source branch and validates the
         // source's pre-lock balance against base + (currentOC+1)*increment.
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx_.getApplyViewContext(),
                 sle,
                 preFeeBalance_,
@@ -165,7 +165,7 @@ PaymentChannelCreate::doApply()
         //                so the source only owes its base reserve.
         // - unsponsored: adj=1  — source owes base + the new increment.
         std::int32_t const ownerCountAdj = *sponsorSle ? 0 : 1;
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx_.getApplyViewContext(),
                 sle,
                 preFeeBalance_ - ctx_.tx[sfAmount].xrp(),

--- a/src/libxrpl/tx/transactors/payment_channel/PaymentChannelFund.cpp
+++ b/src/libxrpl/tx/transactors/payment_channel/PaymentChannelFund.cpp
@@ -93,12 +93,12 @@ PaymentChannelFund::doApply()
         auto const sponsorSle = getTxReserveSponsor(ctx_.getApplyViewContext());
         if (!sponsorSle)
             return sponsorSle.error();  // LCOV_EXCL_LINE
-        if (auto const ret = checkInsufficientReserve(
-                ctx_.getApplyViewContext(), sle, balance, *sponsorSle, {}, j_);
+        if (auto const ret =
+                checkReserve(ctx_.getApplyViewContext(), sle, balance, *sponsorSle, {}, j_);
             !isTesSuccess(ret))
             return ret;
 
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx_.getApplyViewContext(), sle, balance - ctx_.tx[sfAmount], {}, {}, j_);
             !isTesSuccess(ret))
             return tecUNFUNDED;

--- a/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
+++ b/src/libxrpl/tx/transactors/token/MPTokenIssuanceCreate.cpp
@@ -135,7 +135,7 @@ MPTokenIssuanceCreate::create(
 
     if (args.priorBalance)
     {
-        if (auto const ret = checkInsufficientReserve(
+        if (auto const ret = checkReserve(
                 ctx, acct, *(args.priorBalance), sponsorSle, {.ownerCountDelta = 1}, journal);
             !isTesSuccess(ret))
             return std::unexpected(ret);  // tecINSUFFICIENT_RESERVE

--- a/src/libxrpl/tx/transactors/token/TrustSet.cpp
+++ b/src/libxrpl/tx/transactors/token/TrustSet.cpp
@@ -538,7 +538,7 @@ TrustSet::doApply()
             // should be checked PreFunded Sponsor before increaseOwnerCount()
             // For PreFunded sponsors, we need to check if there are sufficient reserves before
             // calling increaseOwnerCount().
-            if (auto const ret = checkInsufficientReserve(
+            if (auto const ret = checkReserve(
                     ctx_.getApplyViewContext(),
                     sleLowAccount,
                     preFeeBalance_,
@@ -572,7 +572,7 @@ TrustSet::doApply()
             // should be checked PreFunded Sponsor before increaseOwnerCount()
             // For PreFunded sponsors, we need to check if there are sufficient reserves before
             // calling increaseOwnerCount().
-            if (auto const ret = checkInsufficientReserve(
+            if (auto const ret = checkReserve(
                     ctx_.getApplyViewContext(),
                     sleHighAccount,
                     preFeeBalance_,
@@ -612,8 +612,8 @@ TrustSet::doApply()
         }
         // Reserve is not scaled by load.
         else if (
-            auto const ret = checkInsufficientReserve(
-                ctx_.getApplyViewContext(), sle, preFeeBalance_, *sponsorSle, {}, j_);
+            auto const ret =
+                checkReserve(ctx_.getApplyViewContext(), sle, preFeeBalance_, *sponsorSle, {}, j_);
             !freeTrustLine && bReserveIncrease && !isTesSuccess(ret))
         {
             JLOG(j_.trace()) << "Delay transaction: Insufficent reserve to "
@@ -643,7 +643,7 @@ TrustSet::doApply()
         return tecNO_LINE_REDUNDANT;
     }
     else if (
-        auto const ret = checkInsufficientReserve(
+        auto const ret = checkReserve(
             ctx_.getApplyViewContext(),
             sle,
             preFeeBalance_,


### PR DESCRIPTION
## High Level Overview of Change

Title says it all

### Context of Change

Comment from @Tapanito, general PR cleanup

### API Impact

N/A