### PR TITLE
fix sponsor fee

### DIFF
--- a/src/libxrpl/tx/invariants/VaultInvariant.cpp
+++ b/src/libxrpl/tx/invariants/VaultInvariant.cpp
@@ -222,7 +222,10 @@ ValidVault::deltaAssetsTxAccount(STTx const& tx, XRPAmount fee) const
     if (!ret.has_value() || !vaultAsset.native())
         return ret;
 
-    if (auto const delegate = tx[~sfDelegate]; delegate.has_value() && *delegate != tx[sfAccount])
+    // Only add the fee back if tx[sfAccount] actually paid it. When the fee is
+    // paid by someone else (a delegate or a fee sponsor), the
+    // account's XRP balance moved only by the vault amount.
+    if (tx.getFeePayerID() != tx[sfAccount])
         return ret;
 
     ret->delta += fee.drops();

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -4565,6 +4565,56 @@ public:
         BEAST_EXPECT(issuerSponsoredAfter == issuerSponsoredBefore);
     }
 
+    void
+    testFeeSponsoredVaultInvariant()
+    {
+        // The ValidVault invariant checks that the vault's balance and the
+        // depositor's balance change by equal amounts. For XRP vaults it adds the
+        // fee back into the depositor's balance change: normally the depositor
+        // pays the fee, so their balance drops by (deposit amount + fee), and
+        // adding the fee back leaves just the deposit amount to compare against
+        // the vault. But when a fee sponsor pays, the depositor's balance drops
+        // by only the deposit amount, so the fee must NOT be added back or the
+        // equal-amount check fails.
+        testcase("Fee-sponsored VaultDeposit/VaultWithdraw pass ValidVault invariant");
+        using namespace test::jtx;
+
+        Env env{*this, testableAmendments()};
+        Account const alice("alice");
+        Account const sponsor("sponsor");
+        env.fund(XRP(10000), alice, sponsor);
+        env.close();
+
+        PrettyAsset const xrpAsset{xrpIssue(), 1'000'000};
+        Vault const vault{env};
+        auto [vaultTx, vaultKeylet] = vault.create({.owner = alice, .asset = xrpAsset});
+        env(vaultTx);
+        env.close();
+
+        // Control: the same deposit shape, unsponsored, succeeds.
+        env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = xrpAsset(100)}),
+            Ter(tesSUCCESS));
+        env.close();
+
+        // Fee-sponsored (co-signed) deposit succeeds.
+        env(vault.deposit({.depositor = alice, .id = vaultKeylet.key, .amount = xrpAsset(100)}),
+            Fee(XRP(1)),
+            sponsor::As(sponsor, spfSponsorFee),
+            Sig(sfSponsorSignature, sponsor),
+            Ter(tesSUCCESS));
+        env.close();
+
+        // The same helper (deltaAssetsTxAccount) drives the withdraw path, so a
+        // fee-sponsored withdrawal back to the depositor's own account also
+        // passes on the destination side.
+        env(vault.withdraw({.depositor = alice, .id = vaultKeylet.key, .amount = xrpAsset(50)}),
+            Fee(XRP(1)),
+            sponsor::As(sponsor, spfSponsorFee),
+            Sig(sfSponsorSignature, sponsor),
+            Ter(tesSUCCESS));
+        env.close();
+    }
+
 protected:
     void
     testSponsor()
@@ -4602,6 +4652,8 @@ protected:
 
         testZeroBalanceSponsoredPaymentFeePayerCheck();
         testTrustSetCounterpartySponsorMisroute();
+
+        testFeeSponsoredVaultInvariant();
     }
 
     void


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
Fix ValidVault invariant false-positive on fee-sponsored (and delegate-paid) XRP vault deposits/withdraws by only adding the tx fee back to the depositor's balance delta when the depositor actually paid it.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
