### PR TITLE
fix: Change correct call sites to decreaseOwnerCountForObject

### DIFF
--- a/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
+++ b/src/libxrpl/tx/transactors/bridge/XChainBridge.cpp
@@ -725,9 +725,8 @@ finalizeClaimHelper(
             }
 
             // Remove the claim id from the ledger
+            decreaseOwnerCountForObject(outerSb, sleOwner, sleClaimID, 1, j);
             outerSb.erase(sleClaimID);
-
-            decreaseOwnerCount(outerSb, sleOwner, {}, 1, j);
         }
     }
 

--- a/src/libxrpl/tx/transactors/did/DIDDelete.cpp
+++ b/src/libxrpl/tx/transactors/did/DIDDelete.cpp
@@ -50,8 +50,7 @@ DIDDelete::deleteSLE(ApplyView& view, SLE::pointer sle, AccountID const owner, b
     if (!sleOwner)
         return tecINTERNAL;  // LCOV_EXCL_LINE
 
-    decreaseOwnerCount(view, sleOwner, {}, 1, j);
-    view.update(sleOwner);
+    decreaseOwnerCountForObject(view, sleOwner, sle, 1, j);
 
     // Remove object from ledger
     view.erase(sle);

--- a/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanBrokerDelete.cpp
@@ -186,8 +186,6 @@ LoanBrokerDelete::doApply()
 
     view().erase(brokerPseudoSLE);
 
-    view().erase(broker);
-
     {
         auto owner = view().peek(keylet::account(accountID_));
         if (!owner)
@@ -195,8 +193,10 @@ LoanBrokerDelete::doApply()
 
         // Decreases the owner count by two: one for the LoanBroker object, and
         // one for the pseudo-account.
-        decreaseOwnerCount(view(), owner, {}, 2, j_);
+        decreaseOwnerCountForObject(view(), owner, broker, 2, j_);
     }
+
+    view().erase(broker);
 
     associateAsset(*broker, vaultAsset);
 

--- a/src/libxrpl/tx/transactors/lending/LoanDelete.cpp
+++ b/src/libxrpl/tx/transactors/lending/LoanDelete.cpp
@@ -109,7 +109,7 @@ LoanDelete::doApply()
     // Decrement the LoanBroker's owner count.
     // The broker's owner count is solely for the number of outstanding loans,
     // and is distinct from the broker's pseudo-account's owner count
-    decreaseOwnerCount(view, brokerSle, {}, 1, j_);
+    decreaseOwnerCountForObject(view, brokerSle, loanSle, 1, j_);
 
     // If there are no loans left, then any remaining debt must be forgiven,
     // because there is no other way to pay it back.
@@ -130,7 +130,7 @@ LoanDelete::doApply()
         }
     }
     // Decrement the borrower's owner count
-    decreaseOwnerCount(view, borrowerSle, {}, 1, j_);
+    decreaseOwnerCountForObject(view, borrowerSle, loanSle, 1, j_);
 
     // These associations shouldn't do anything, but do them just to be safe
     associateAsset(*loanSle, vaultAsset);

--- a/src/libxrpl/tx/transactors/oracle/OracleDelete.cpp
+++ b/src/libxrpl/tx/transactors/oracle/OracleDelete.cpp
@@ -71,7 +71,7 @@ OracleDelete::deleteOracle(
         return tecINTERNAL;  // LCOV_EXCL_LINE
 
     std::uint32_t const count = sle->getFieldArray(sfPriceDataSeries).size() > 5 ? 2 : 1;
-    decreaseOwnerCount(view, sleOwner, {}, count, j);
+    decreaseOwnerCountForObject(view, sleOwner, sle, count, j);
     view.erase(sle);
 
     return tesSUCCESS;

--- a/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainDelete.cpp
+++ b/src/libxrpl/tx/transactors/permissioned_domain/PermissionedDomainDelete.cpp
@@ -65,7 +65,7 @@ PermissionedDomainDelete::doApply()
     XRPL_ASSERT(
         ownerSle && ownerSle->getFieldU32(sfOwnerCount) > 0,
         "xrpl::PermissionedDomainDelete::doApply : nonzero owner count");
-    decreaseOwnerCount(view(), ownerSle, {}, 1, ctx_.journal);
+    decreaseOwnerCountForObject(view(), ownerSle, slePd, 1, ctx_.journal);
     view().erase(slePd);
 
     return tesSUCCESS;

--- a/src/libxrpl/tx/transactors/vault/VaultDelete.cpp
+++ b/src/libxrpl/tx/transactors/vault/VaultDelete.cpp
@@ -154,7 +154,7 @@ VaultDelete::doApply()
         return tefBAD_LEDGER;
         // LCOV_EXCL_STOP
     }
-    decreaseOwnerCount(view(), pseudoAcct, {}, 1, j_);
+    decreaseOwnerCountForObject(view(), pseudoAcct, mpt, 1, j_);
 
     view().erase(mpt);
 
@@ -213,7 +213,7 @@ VaultDelete::doApply()
     }
 
     // We are destroying Vault and PseudoAccount, hence decrease by 2
-    decreaseOwnerCount(view(), owner, {}, 2, j_);
+    decreaseOwnerCountForObject(view(), owner, vault, 2, j_);
 
     // Destroy the vault.
     view().erase(vault);

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -4807,6 +4807,79 @@ public:
         env.close();
     }
 
+    void
+    testSponsoredObjectDeletionRefund()
+    {
+        // Deleting a co-signed reserve-sponsored object must
+        // refund the sponsor's SponsoringOwnerCount back to zero.
+        testcase("Sponsored object deletion refunds sponsor owner count");
+        using namespace test::jtx;
+
+        Env env{*this, testableAmendments()};
+        Account const sponsor("sponsor");
+        env.fund(XRP(100000), sponsor);
+        env.close();
+
+        // Sponsored Check deletion - verify decreaseOwnerCountForObject
+        // (used by CheckCancel) reads the object's sfSponsor field and refunds
+        // the sponsor's owner count.
+        {
+            testcase("  — Check deletion");
+
+            Account const checkOwner("check_owner");
+            Account const dest("check_dest");
+            env.fund(XRP(100000), checkOwner, dest);
+            env.close();
+
+            // Create a check with co-signed reserve sponsorship. This bumps the
+            // sponsor's sfSponsoringOwnerCount rather than the check owner's.
+            auto const checkSeq = env.seq(checkOwner);
+            env(check::create(checkOwner, dest, XRP(1)),
+                sponsor::As(sponsor, spfSponsorReserve),
+                Sig(sfSponsorSignature, sponsor));
+            env.close();
+
+            auto sponsorCountBefore = sponsoringOwnerCount(env, sponsor);
+            BEAST_EXPECT(sponsorCountBefore == 1);  // check costs 1 owner count
+
+            // Cancel (delete) the check.
+            env(check::cancel(checkOwner, keylet::check(checkOwner, checkSeq).key));
+            env.close();
+
+            auto sponsorCountAfter = sponsoringOwnerCount(env, sponsor);
+            BEAST_EXPECT(sponsorCountAfter == 0);  // fully refunded
+        }
+
+        // Sponsored TrustSet (trust line) deletion - verify the sponsor
+        // refund works when a sponsored trust line is deleted
+        {
+            testcase("  — TrustLine deletion");
+
+            Account const issuer("issuer");
+            Account const holder("holder");
+            env.fund(XRP(100000), issuer, holder);
+            env.close();
+
+            auto const usd = issuer["USD"];
+
+            // Create trust line with sponsorship on the holder side
+            env(trust(holder, usd(1000)),
+                sponsor::As(sponsor, spfSponsorReserve),
+                Sig(sfSponsorSignature, sponsor));
+            env.close();
+
+            auto sponsorCountBefore = sponsoringOwnerCount(env, sponsor);
+            BEAST_EXPECT(sponsorCountBefore == 1);  // trust line costs 1
+
+            // Delete the trust line by clearing it to default
+            env(trust(holder, usd(0)));
+            env.close();
+
+            auto sponsorCountAfter = sponsoringOwnerCount(env, sponsor);
+            BEAST_EXPECT(sponsorCountAfter == 0);  // fully refunded
+        }
+    }
+
 protected:
     void
     testSponsor()
@@ -4846,6 +4919,7 @@ protected:
         testTrustSetCounterpartySponsorMisroute();
 
         testFeeSponsoredVaultInvariant();
+        testSponsoredObjectDeletionRefund();
     }
 
     void


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change
Note: this change is a no-op today, as every object touched here is currently unsponsorable (their create-side transactions aren't on the spfSponsorReserve allow-list), so sfSponsor is never set and decreaseOwnerCountForObject resolves to the same null sponsor as before. It's needed for when these objects become reserve-sponsorable in the future, so the sponsor's owner count is correctly refunded on deletion.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
