### PR TITLE
chore: Use same compiler in Nix devshell as in CI

### DIFF
--- a/docs/build/environment.md
+++ b/docs/build/environment.md
@@ -33,9 +33,10 @@ with a single command and without installing anything system-wide:
 nix --experimental-features 'nix-command flakes' develop
 ```
 
-On **Linux**, Nix also provides the compiler (GCC). On **macOS**, the shell uses
-your **system-wide Apple Clang** as the compiler, so you still need to manage
-its version (see below).
+On **Linux**, Nix also provides the compiler (GCC); on **macOS**, it provides
+Clang. If you instead opt to use your system-wide Apple Clang (via
+`nix develop .#apple-clang`), you need to manage its version yourself (see
+below).
 
 See [Using the Nix development shell](./nix.md) for installation and usage
 details, including how to select a different compiler.
@@ -48,10 +49,10 @@ details, including how to select a different compiler.
 
 ### macOS: managing the Apple Clang version
 
-Because the Nix shell uses the system-wide Apple Clang on macOS, the compiler
-version is whatever your installed Xcode (or Command Line Tools) provides. The
-following command should return a version greater than or equal to the
-[minimum required](#tested-compiler-versions):
+If you use your system-wide Apple Clang on macOS (via `nix develop .#apple-clang`),
+the compiler version is whatever your installed Xcode (or Command Line Tools)
+provides. The following command should return a version greater than or equal to
+the [minimum required](#tested-compiler-versions):
 
 ```bash
 clang --version

--- a/docs/build/nix.md
+++ b/docs/build/nix.md
@@ -9,7 +9,7 @@ This guide explains how to use Nix to set up a reproducible development environm
 - **Reproducible environment**: Everyone gets the same versions of tools and compilers
 - **Matches CI**: The Linux CI runs in Docker images built from this exact Nix environment
 - **No system pollution**: Dependencies are isolated and don't affect your system packages
-- **Multiple compiler versions**: Easily switch between different GCC and Clang versions
+- **Consistent compilers**: The GCC and Clang shells use the same versions as CI
 - **Quick setup**: Get started with a single command
 - **Works on Linux and macOS**: Consistent experience across platforms
 
@@ -31,8 +31,8 @@ This will:
 
 - Download and set up all required development tools (CMake, Ninja, Conan, etc.)
 - Configure the appropriate compiler for your platform:
-  - **Linux**: GCC 15.2 (provided by Nix)
-  - **macOS**: Apple Clang (your system compiler)
+  - **Linux**: GCC (provided by Nix)
+  - **macOS**: Clang (provided by Nix)
 
 The first time you run this command, it will take a few minutes to download and build the environment. Subsequent runs will be much faster.
 
@@ -40,12 +40,12 @@ The first time you run this command, it will take a few minutes to download and 
 
 - **Linux**: `nix develop` gives you a shell with all the tooling necessary to
   develop xrpld and with GCC 15.2 (also provided by Nix). There are no caveats.
-- **macOS**: `nix develop` gives you a full environment too. The compiler is
-  your system-wide Apple Clang, while every other tool — including Conan — is
-  provided by Nix. Conan has no binary in the Nix cache for macOS, so it is
-  built from source the first time you enter the shell, which makes the initial
-  setup slower (this is handled automatically; see
-  [`nix/devshell.nix`](../../nix/devshell.nix)).
+- **macOS**: `nix develop` gives you a full environment too, with Clang (and
+  every other tool, including Conan) provided by Nix. To use your system-wide
+  Apple Clang instead, enter `nix develop .#apple-clang`. Conan has no binary in
+  the Nix cache for macOS, so it is built from source the first time you enter
+  the shell, which makes the initial setup slower (this is handled
+  automatically; see [`nix/devshell.nix`](../../nix/devshell.nix)).
 
 > [!TIP]
 > To avoid typing `--experimental-features 'nix-command flakes'` every time, you can permanently enable flakes by creating `~/.config/nix/nix.conf`:
@@ -62,7 +62,9 @@ The first time you run this command, it will take a few minutes to download and 
 
 ### Choosing a different compiler
 
-A compiler can be chosen by providing its name with the `.#` prefix, e.g. `nix develop .#gcc15`.
+A compiler can be chosen by providing its name with the `.#` prefix, e.g. `nix develop .#clang`.
+The `.#gcc` and `.#clang` shells provide the same GCC and Clang versions used in CI
+(pinned in [`nix/packages.nix`](../../nix/packages.nix)).
 Use `nix flake show` to see all the available development shells.
 
 Use `nix develop .#no-compiler` to use the compiler from your system.
@@ -70,11 +72,11 @@ Use `nix develop .#no-compiler` to use the compiler from your system.
 ### Example Usage
 
 ```bash
-# Use GCC 14
-nix develop .#gcc14
+# Use GCC (same version as CI)
+nix develop .#gcc
 
-# Use Clang 19
-nix develop .#clang19
+# Use Clang (same version as CI)
+nix develop .#clang
 
 # Use default for your platform
 nix develop

--- a/nix/ci-env.nix
+++ b/nix/ci-env.nix
@@ -4,14 +4,16 @@
   ...
 }:
 let
-  inherit (import ./packages.nix { inherit pkgs; }) commonPackages;
-  inherit (pkgs) lib;
+  inherit (import ./packages.nix { inherit pkgs; })
+    commonPackages
+    gccPackage
+    llvmPackages
+    llvmVersion
+    ;
 
-  # Underlying compiler toolchains to wrap. Bump these in one place to
-  # roll the whole environment forward.
-  customGccPackage = pkgs.gcc15;
-  customLlvmPackages = pkgs.llvmPackages_22;
-  customClangMajor = lib.versions.major (lib.getVersion customLlvmPackages.clang-unwrapped);
+  # Underlying compiler toolchains to wrap (versions pinned in packages.nix).
+  customGccPackage = gccPackage;
+  customLlvmPackages = llvmPackages;
 
   # binutils wrapped to emit binaries that reference the custom glibc
   # (dynamic linker path, library search path, RPATH).
@@ -90,7 +92,7 @@ let
     extraBuildCommands = ''
       rsrc="$out/resource-root"
       mkdir "$rsrc"
-      ln -s "${customLlvmPackages.clang-unwrapped.lib}/lib/clang/${customClangMajor}/include" "$rsrc/include"
+      ln -s "${customLlvmPackages.clang-unwrapped.lib}/lib/clang/${toString llvmVersion}/include" "$rsrc/include"
       ln -s "${customCompilerRt.out}/lib" "$rsrc/lib"
       ln -s "${customCompilerRt.out}/share" "$rsrc/share" || true
       echo "-resource-dir=$rsrc" >> $out/nix-support/cc-cflags

--- a/nix/devshell.nix
+++ b/nix/devshell.nix
@@ -1,127 +1,57 @@
 { pkgs, ... }:
 let
-  inherit (import ./packages.nix { inherit pkgs; }) commonPackages;
+  inherit (import ./packages.nix { inherit pkgs; })
+    commonPackages
+    gccVersion
+    llvmPackages
+    ;
 
-  # Supported compiler versions
-  gccVersion = pkgs.lib.range 13 15;
-  clangVersions = pkgs.lib.range 18 21;
+  # Plain nixpkgs stdenvs — no custom glibc, unlike ci-env.nix.
+  gccStdenv = pkgs."gcc${toString gccVersion}Stdenv";
+  clangStdenv = llvmPackages.stdenv;
 
-  defaultCompiler = if pkgs.stdenv.isDarwin then "apple-clang" else "gcc";
-  defaultGccVersion = pkgs.lib.last gccVersion;
-  defaultClangVersion = pkgs.lib.last clangVersions;
-
-  strToCompilerEnv =
-    compiler: version:
-    (
-      if compiler == "gcc" then
-        let
-          gccPkg = pkgs."gcc${toString version}Stdenv" or null;
-        in
-        if gccPkg != null && builtins.elem version gccVersion then
-          gccPkg
-        else
-          throw "Invalid GCC version: ${toString version}. Must be one of: ${toString gccVersion}"
-      else if compiler == "clang" then
-        let
-          clangPkg = pkgs."llvmPackages_${toString version}".stdenv or null;
-        in
-        if clangPkg != null && builtins.elem version clangVersions then
-          clangPkg
-        else
-          throw "Invalid Clang version: ${toString version}. Must be one of: ${toString clangVersions}"
-      else if compiler == "apple-clang" || compiler == "none" then
-        pkgs.stdenvNoCC
-      else
-        throw "Invalid compiler: ${compiler}. Must be one of: gcc, clang, apple-clang, none"
-    );
-
-  # Helper function to create a shell with a specific compiler
+  # compilerName is the command used to print the version, or null for none.
   makeShell =
     {
-      compiler ? defaultCompiler,
-      version ? (
-        if compiler == "gcc" then
-          defaultGccVersion
-        else if compiler == "clang" then
-          defaultClangVersion
-        else
-          null
-      ),
+      stdenv,
+      compilerName,
     }:
     let
-      compilerStdEnv = strToCompilerEnv compiler version;
-
-      compilerName =
-        if compiler == "apple-clang" then
-          "clang"
-        else if compiler == "none" then
-          null
-        else
-          compiler;
-
-      gccOnMacWarning =
-        if pkgs.stdenv.isDarwin && compiler == "gcc" then
-          ''
-            echo "WARNING: Using GCC on macOS with Conan may not work."
-            echo "         Consider using 'nix develop .#clang' or the default shell instead."
-            echo ""
-          ''
-        else
-          "";
-
       compilerVersion =
-        if compilerName != null then
+        if compilerName == null then
+          ''echo "No compiler specified - using system compiler"''
+        else
           ''
             echo "Compiler: "
             ${compilerName} --version
-          ''
-        else
-          ''
-            echo "No compiler specified - using system compiler"
           '';
-
-      shellAttrs = {
-        packages = commonPackages;
-
-        shellHook = ''
-          echo "Welcome to xrpld development shell";
-          ${gccOnMacWarning}${compilerVersion}
-        '';
-      };
     in
-    pkgs.mkShell.override { stdenv = compilerStdEnv; } shellAttrs;
-
-  # Generate shells for each compiler version
-  gccShells = builtins.listToAttrs (
-    map (version: {
-      name = "gcc${toString version}";
-      value = makeShell {
-        compiler = "gcc";
-        version = version;
-      };
-    }) gccVersion
-  );
-
-  clangShells = builtins.listToAttrs (
-    map (version: {
-      name = "clang${toString version}";
-      value = makeShell {
-        compiler = "clang";
-        version = version;
-      };
-    }) clangVersions
-  );
-
+    (pkgs.mkShell.override { inherit stdenv; }) {
+      packages = commonPackages;
+      shellHook = ''
+        echo "Welcome to xrpld development shell";
+        ${compilerVersion}
+      '';
+    };
 in
-gccShells
-// clangShells
-// {
-  # Default shells
-  default = makeShell { };
-  gcc = makeShell { compiler = "gcc"; };
-  clang = makeShell { compiler = "clang"; };
+rec {
+  # macOS: Nix Clang. Linux: Nix GCC.
+  default = if pkgs.stdenv.isDarwin then clang else gcc;
 
-  # No compiler
-  no-compiler = makeShell { compiler = "none"; };
-  apple-clang = makeShell { compiler = "apple-clang"; };
+  gcc = makeShell {
+    stdenv = gccStdenv;
+    compilerName = "gcc";
+  };
+
+  clang = makeShell {
+    stdenv = clangStdenv;
+    compilerName = "clang";
+  };
+
+  # Nix provides no compiler; use the one from your system (e.g. Apple Clang).
+  no-compiler = makeShell {
+    stdenv = pkgs.stdenvNoCC;
+    compilerName = null;
+  };
+  apple-clang = no-compiler;
 }

--- a/nix/packages.nix
+++ b/nix/packages.nix
@@ -1,15 +1,33 @@
 { pkgs }:
 let
+  # Compiler versions used across the dev shell and the CI environment.
+  gccVersion = 15;
+  llvmVersion = 22;
+
+  gccPackage = pkgs."gcc${toString gccVersion}";
+  llvmPackages = pkgs."llvmPackages_${toString llvmVersion}";
+
+  # Bound explicitly so it tracks llvmPackages above, not the `with pkgs` default.
+  clangTools = llvmPackages.clang-tools;
+
   # In LLVM 22, run-clang-tidy.py moved from share/clang/ to bin/, so nixpkgs
   # clang-tools no longer links it. Wrap it manually.
   runClangTidy = pkgs.writeShellScriptBin "run-clang-tidy" ''
-    exec ${pkgs.python3}/bin/python3 ${pkgs.llvmPackages_22.clang-unwrapped}/bin/run-clang-tidy "$@"
+    exec ${pkgs.python3}/bin/python3 ${llvmPackages.clang-unwrapped}/bin/run-clang-tidy "$@"
   '';
 in
 {
+  inherit
+    gccVersion
+    llvmVersion
+    gccPackage
+    llvmPackages
+    ;
+
   commonPackages = with pkgs; [
     ccache
     clangbuildanalyzer
+    clangTools
     cmake
     conan
     curlMinimal # needed for codecov/codecov-action
@@ -23,7 +41,6 @@ in
     gnumake
     gnupg # needed for signing commits & codecov/codecov-action
     graphviz
-    llvmPackages_22.clang-tools
     less # needed for git diff
     mold
     nettools # provides netstat, used to debug failures in CI


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

- Centralized compiler versions in `nix/packages.nix`** — single source of truth (`gccVersion = 15`, `llvmVersion = 22`), consumed by both the dev shell and CI env so they can't drift.
- So, **`.#clang` bumped 21 → 22**, matching `clang-tidy` and CI.
- **Dev shell now uses single GCC/Clang versions matching CI** — dropped the per-version shells (`.#gcc13/14`, `.#clang18–21`); only `.#gcc` and `.#clang` remain.
- **macOS default shell now uses Nix Clang** (22) instead of system Apple Clang; `.#apple-clang` remains for the system compiler.

Cleanups:
- **Simplified `ci-env.nix`** — reuses the shared versions and drops `customClangMajor` (derives the resource path from `llvmVersion`).
- **Tidied `devshell.nix`** — `default` references the `gcc`/`clang` shells (no duplication), `apple-clang` aliases `no-compiler`, and removed the GCC-on-macOS warning and unused `makeShell` defaults.
- **Updated docs** (`docs/build/nix.md`, `docs/build/environment.md`) to reflect the Nix Clang default on macOS and the single-version shells.

Is it possible to have apple-clang built by Nix for macOS?
Short answer: **no — genuine `apple-clang` can't be built or shipped by Nix.**

**`apple-clang` is Apple's proprietary fork of Clang**, distributed *only* as part of Xcode / Command Line Tools. Apple doesn't provide a fully buildable source tree for it (it has closed components and its own version scheme, e.g. "Apple clang 17" ≠ upstream LLVM 17), and its license doesn't allow nixpkgs to redistribute the Xcode toolchain. So there's nothing for nixpkgs to build from or cache.

We want the defaults to work nicely, it's impossible with system-wide Apple-Clang, because clang-tidy inside nix environment will use Nix's libc++, which causes lots of errors.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
