### PR TITLE
ci: Do not run conflict checker when label is applied

### DIFF
--- a/.github/workflows/check-pr-commits.yml
+++ b/.github/workflows/check-pr-commits.yml
@@ -10,4 +10,5 @@ permissions:
 
 jobs:
   check_commits:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'IgnoreConflicts') }}
     uses: XRPLF/actions/.github/workflows/check-pr-commits.yml@e2c7f400d1e85ae65dad552fd425169fbacca4a3

--- a/.github/workflows/check-pr-commits.yml
+++ b/.github/workflows/check-pr-commits.yml
@@ -10,5 +10,4 @@ permissions:
 
 jobs:
   check_commits:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'IgnoreConflicts') }}
     uses: XRPLF/actions/.github/workflows/check-pr-commits.yml@e2c7f400d1e85ae65dad552fd425169fbacca4a3

--- a/.github/workflows/conflicting-pr.yml
+++ b/.github/workflows/conflicting-pr.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   main:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'IgnoreConflicts') }}
     runs-on: ubuntu-latest
     steps:
       - name: Check if PRs are dirty


### PR DESCRIPTION
## High Level Overview of Change

This change prevents the conflict checker from running when the `IgnoreConflicts` label has been applied to the PR.

### Context of Change

As many developers are contributing code to the codebase, conflicts are inevitable. The email and comments that result from the conflict checker workflow can be annoying/overwhelming. This change will allow developers to explicitly opt out of the conflict checker. The label must be individually applied to each PR.