### PR TITLE
fix: SponsorshipSet cannot create empty ltSPONSORSHIP objects

### DIFF
--- a/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
@@ -29,15 +29,15 @@ hasSponsorshipBudget(
     std::optional<STAmount> const& feeAmount,
     std::optional<std::uint32_t> const& remainingOwnerCount)
 {
+    // A field the transaction omits keeps whatever the existing object holds,
+    // so fall back to the current SLE value when the tx does not set it.
     bool const hasFeeAmount = feeAmount
         ? *feeAmount > beast::kZero
-        : sponsorshipSle && sponsorshipSle->isFieldPresent(sfFeeAmount) &&
-            sponsorshipSle->getFieldAmount(sfFeeAmount) > beast::kZero;
+        : sponsorshipSle && (*sponsorshipSle)[~sfFeeAmount].value_or(STAmount{0}) > beast::kZero;
 
     bool const hasRemainingOwnerCount = remainingOwnerCount
         ? *remainingOwnerCount > 0
-        : sponsorshipSle && sponsorshipSle->isFieldPresent(sfRemainingOwnerCount) &&
-            sponsorshipSle->getFieldU32(sfRemainingOwnerCount) > 0;
+        : sponsorshipSle && (*sponsorshipSle)[~sfRemainingOwnerCount].value_or(0) > 0;
 
     return hasFeeAmount || hasRemainingOwnerCount;
 }
@@ -154,6 +154,9 @@ SponsorshipSet::preclaim(PreclaimContext const& ctx)
     if (ctx.tx.isFlag(tfDeleteObject) && !sponsorshipSle)
         return tecNO_ENTRY;
 
+    // Reject creating or updating a Sponsorship that would be left with no
+    // budget (neither a positive FeeAmount nor a positive RemainingOwnerCount).
+    // Such an object is unusable yet still consumes the sponsor's reserve.
     if (!ctx.tx.isFlag(tfDeleteObject) &&
         !hasSponsorshipBudget(sponsorshipSle, ctx.tx[~sfFeeAmount], ctx.tx[~sfRemainingOwnerCount]))
         return temMALFORMED;
@@ -237,11 +240,6 @@ SponsorshipSet::doApply()
     auto const remainingOwnerCount = ctx_.tx[~sfRemainingOwnerCount];
 
     bool const hasPositiveFeeAmount = feeAmount.has_value() && *feeAmount > beast::kZero;
-
-    // Defense-in-depth: preclaim already rejects a Sponsorship left with no
-    // fee or reserve budget, so this branch is unreachable in practice.
-    if (!hasSponsorshipBudget(sponsorshipSle, feeAmount, remainingOwnerCount))
-        return tecINTERNAL;  // LCOV_EXCL_LINE
 
     auto reserveSponsorAccSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!reserveSponsorAccSle)

--- a/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
@@ -241,7 +241,7 @@ SponsorshipSet::doApply()
     // Defense-in-depth: preclaim already rejects a Sponsorship left with no
     // fee or reserve budget, so this branch is unreachable in practice.
     if (!hasSponsorshipBudget(sponsorshipSle, feeAmount, remainingOwnerCount))
-        return temMALFORMED;  // LCOV_EXCL_LINE
+        return tecINTERNAL;  // LCOV_EXCL_LINE
 
     auto reserveSponsorAccSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!reserveSponsorAccSle)

--- a/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
@@ -238,8 +238,10 @@ SponsorshipSet::doApply()
 
     bool const hasPositiveFeeAmount = feeAmount.has_value() && *feeAmount > beast::kZero;
 
+    // Defense-in-depth: preclaim already rejects a Sponsorship left with no
+    // fee or reserve budget, so this branch is unreachable in practice.
     if (!hasSponsorshipBudget(sponsorshipSle, feeAmount, remainingOwnerCount))
-        return temMALFORMED;
+        return temMALFORMED;  // LCOV_EXCL_LINE
 
     auto reserveSponsorAccSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!reserveSponsorAccSle)

--- a/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
+++ b/src/libxrpl/tx/transactors/sponsor/SponsorshipSet.cpp
@@ -19,8 +19,28 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 namespace xrpl {
+
+static bool
+hasSponsorshipBudget(
+    SLE::const_ref sponsorshipSle,
+    std::optional<STAmount> const& feeAmount,
+    std::optional<std::uint32_t> const& remainingOwnerCount)
+{
+    bool const hasFeeAmount = feeAmount
+        ? *feeAmount > beast::kZero
+        : sponsorshipSle && sponsorshipSle->isFieldPresent(sfFeeAmount) &&
+            sponsorshipSle->getFieldAmount(sfFeeAmount) > beast::kZero;
+
+    bool const hasRemainingOwnerCount = remainingOwnerCount
+        ? *remainingOwnerCount > 0
+        : sponsorshipSle && sponsorshipSle->isFieldPresent(sfRemainingOwnerCount) &&
+            sponsorshipSle->getFieldU32(sfRemainingOwnerCount) > 0;
+
+    return hasFeeAmount || hasRemainingOwnerCount;
+}
 
 TxConsequences
 SponsorshipSet::makeTxConsequences(PreflightContext const& ctx)
@@ -134,6 +154,10 @@ SponsorshipSet::preclaim(PreclaimContext const& ctx)
     if (ctx.tx.isFlag(tfDeleteObject) && !sponsorshipSle)
         return tecNO_ENTRY;
 
+    if (!ctx.tx.isFlag(tfDeleteObject) &&
+        !hasSponsorshipBudget(sponsorshipSle, ctx.tx[~sfFeeAmount], ctx.tx[~sfRemainingOwnerCount]))
+        return temMALFORMED;
+
     return tesSUCCESS;
 }
 
@@ -213,6 +237,9 @@ SponsorshipSet::doApply()
     auto const remainingOwnerCount = ctx_.tx[~sfRemainingOwnerCount];
 
     bool const hasPositiveFeeAmount = feeAmount.has_value() && *feeAmount > beast::kZero;
+
+    if (!hasSponsorshipBudget(sponsorshipSle, feeAmount, remainingOwnerCount))
+        return temMALFORMED;
 
     auto reserveSponsorAccSle = getTxReserveSponsor(ctx_.getApplyViewContext());
     if (!reserveSponsorAccSle)

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -591,20 +591,28 @@ public:
             env.close();
             BEAST_EXPECT(!env.le(keylet::sponsorship(sponsor, alice)));
 
-            // create sponsorship with zero value
+            // Cannot create sponsorship with no fee or reserve budget. MaxFee
+            // and flags do not make a sponsorship object useful by themselves.
+            env(sponsor::set(sponsor, 0),
+                sponsor::SponseeAcc(alice),
+                Fee(XRP(1)),
+                Ter(temMALFORMED));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::sponsorship(sponsor, alice)));
+
+            env(sponsor::set_max_fee(sponsor, 0, XRP(1)),
+                sponsor::SponseeAcc(alice),
+                Fee(XRP(1)),
+                Ter(temMALFORMED));
+            env.close();
+            BEAST_EXPECT(!env.le(keylet::sponsorship(sponsor, alice)));
+
             env(sponsor::set(sponsor, 0, 0, XRP(0), XRP(0)),
                 sponsor::SponseeAcc(alice),
-                Fee(XRP(1)));
+                Fee(XRP(1)),
+                Ter(temMALFORMED));
             env.close();
-
-            sle = env.le(keylet::sponsorship(sponsor, alice));
-            BEAST_EXPECT(sle);
-            BEAST_EXPECT(!sle->isFieldPresent(sfRemainingOwnerCount));
-            BEAST_EXPECT(!sle->isFieldPresent(sfFeeAmount));
-            BEAST_EXPECT(!sle->isFieldPresent(sfMaxFee));
-            // verify flags from previous sponsorship are not carried over
-            BEAST_EXPECT(!sle->isFlag(lsfSponsorshipRequireSignForFee));
-            BEAST_EXPECT(!sle->isFlag(lsfSponsorshipRequireSignForReserve));
+            BEAST_EXPECT(!env.le(keylet::sponsorship(sponsor, alice)));
 
             // update sponsorship with non-zero value
             env(sponsor::set(sponsor, 0, 100, XRP(100), XRP(1)),
@@ -644,17 +652,18 @@ public:
                 tfSponsorshipClearRequireSignForReserve,
                 lsfSponsorshipRequireSignForReserve);
 
-            // update sponsorship with zero value
+            // Cannot update sponsorship so both fee and reserve budgets are absent.
             env(sponsor::set(sponsor, 0, 0, XRP(0), XRP(0)),
                 sponsor::SponseeAcc(alice),
-                Fee(XRP(1)));
+                Fee(XRP(1)),
+                Ter(temMALFORMED));
             env.close();
 
             sle = env.le(keylet::sponsorship(sponsor, alice));
             BEAST_EXPECT(sle);
-            BEAST_EXPECT(!sle->isFieldPresent(sfRemainingOwnerCount));
-            BEAST_EXPECT(!sle->isFieldPresent(sfFeeAmount));
-            BEAST_EXPECT(!sle->isFieldPresent(sfMaxFee));
+            BEAST_EXPECT(sle->at(sfRemainingOwnerCount) == 100);
+            BEAST_EXPECT(sle->at(sfFeeAmount) == XRP(100));
+            BEAST_EXPECT(sle->at(sfMaxFee) == XRP(1));
         }
 
         {

--- a/src/test/app/Sponsor_test.cpp
+++ b/src/test/app/Sponsor_test.cpp
@@ -667,6 +667,43 @@ public:
         }
 
         {
+            // Removing one budget field while the other remains keeps the
+            // Sponsorship valid. Starting state (from above):
+            // RemainingOwnerCount = 100, FeeAmount = XRP(100).
+
+            // Remove only FeeAmount (set to 0); RemainingOwnerCount remains.
+            env(sponsor::set_fee(sponsor, 0, XRP(0)),
+                sponsor::SponseeAcc(alice),
+                Fee(XRP(1)),
+                Ter(tesSUCCESS));
+            env.close();
+
+            auto sle = env.le(keylet::sponsorship(sponsor, alice));
+            BEAST_EXPECT(sle);
+            BEAST_EXPECT(!sle->isFieldPresent(sfFeeAmount));
+            BEAST_EXPECT(sle->at(sfRemainingOwnerCount) == 100);
+
+            // Re-add FeeAmount, then remove only RemainingOwnerCount;
+            // FeeAmount remains.
+            env(sponsor::set_fee(sponsor, 0, XRP(100)),
+                sponsor::SponseeAcc(alice),
+                Fee(XRP(1)),
+                Ter(tesSUCCESS));
+            env.close();
+
+            env(sponsor::set_reserve(sponsor, 0, 0),
+                sponsor::SponseeAcc(alice),
+                Fee(XRP(1)),
+                Ter(tesSUCCESS));
+            env.close();
+
+            sle = env.le(keylet::sponsorship(sponsor, alice));
+            BEAST_EXPECT(sle);
+            BEAST_EXPECT(!sle->isFieldPresent(sfRemainingOwnerCount));
+            BEAST_EXPECT(sle->at(sfFeeAmount) == XRP(100));
+        }
+
+        {
             // Update Sponsorship (FeeAmount)
             // set empty FeeAmount
             env(sponsor::set_reserve(sponsor, 0, 100), sponsor::SponseeAcc(alice), Ter(tesSUCCESS));

--- a/src/test/rpc/LedgerEntry_test.cpp
+++ b/src/test/rpc/LedgerEntry_test.cpp
@@ -1899,7 +1899,7 @@ class LedgerEntry_test : public beast::unit_test::Suite
         Account const bob{"bob"};
         env.fund(XRP(10000), alice, bob);
         env.close();
-        env(sponsor::set(alice, 0), sponsor::SponseeAcc(bob));
+        env(sponsor::set(alice, 0, 100), sponsor::SponseeAcc(bob));
         env.close();
         std::string const ledgerHash{to_string(env.closed()->header().hash)};
         auto const sponsorshipIndex = to_string(keylet::sponsorship(alice.id(), bob.id()).key);


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

The absence of a FeeAmount / ReserveCount presence-check in SponsorshipSet::preflight and in the create-branch of doApply at [SponsorshipSet.cpp](https://github.com/sherlock-audit/2026-04-xrp-ledger-april-2026/blob/main/rippled/src/libxrpl/tx/transactors/Sponsor/SponsorshipSet.cpp) will cause reserve-capacity denial-of-service for a sponsor as an attacker (a compromised SponsorFee-granular delegate, or the sponsor themselves making a mistake) will submit SponsorshipSet transactions that create functionally-empty ltSPONSORSHIP objects, each consuming objReserve of the sponsor's required-reserve budget while serving no sponsorship purpose — a direct violation of spec §5.7 invariant ("At least one of FeeAmount or ReserveCount must exist").

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
