### PR TITLE
chore: Run clang_tidy_check with `pass_filenames: false` from pre-commit

### DIFF
--- a/.cspell.config.yaml
+++ b/.cspell.config.yaml
@@ -65,6 +65,7 @@ words:
   - Btrfs
   - Buildx
   - canonicality
+  - canonicalised
   - changespq
   - checkme
   - choco

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,11 @@ repos:
         # as standalone translation units, so they have no compile_commands.json
         # entry to lint (verify_headers checks them transitively).
         exclude: '^include/xrpl/protocol_autogen|\.ipp$'
+        # run-clang-tidy --fix may edit headers included by files it is not run on,
+        # so pre-commit must not split the files across parallel hook invocations.
+        # The script determines the staged files itself and lets run-clang-tidy
+        # handle parallelism internally.
+        pass_filenames: false
       - id: fix-include-style
         name: fix include style
         entry: ./bin/pre-commit/fix_include_style.py

--- a/bin/pre-commit/clang_tidy_check.py
+++ b/bin/pre-commit/clang_tidy_check.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
-"""Pre-commit hook that runs clang-tidy on changed files using run-clang-tidy.
+"""Pre-commit hook that runs clang-tidy on staged files using run-clang-tidy.
 
-The set of files is chosen by pre-commit (see .pre-commit-config.yaml), which
-filters to C/C++ sources and excludes `.ipp` fragments. Headers are linted
-directly: the `verify_headers` build option (ON by default) compiles every
-`.h`/`.hpp` on its own, so each header is the main file of its own
-compile_commands.json entry and run-clang-tidy can analyse it just like a
-`.cpp`.
+The script determines the staged files itself (see `pass_filenames: false` in
+.pre-commit-config.yaml) so run-clang-tidy is run once and handles parallelism
+internally: pre-commit would otherwise split the files across parallel hook
+invocations that race when `--fix` edits a shared header.
 """
 
 from __future__ import annotations
@@ -18,6 +16,11 @@ import sys
 from pathlib import Path
 
 CLANG_TIDY_VERSION = 22
+
+# Extensions run-clang-tidy can analyse: `.cpp` translation units and, thanks to
+# the `verify_headers` build option, `.h`/`.hpp` headers (each has its own
+# compile_commands.json entry). `.ipp` fragments have no entry and are skipped.
+TIDY_EXTENSIONS = {".cpp", ".h", ".hpp"}
 
 
 def find_run_clang_tidy() -> str | None:
@@ -35,11 +38,33 @@ def find_build_dir(repo_root: Path) -> Path | None:
     return None
 
 
+def staged_files(repo_root: Path) -> list[Path]:
+    """Return absolute paths of staged, lint-able C/C++ files.
+
+    `--diff-filter=d` excludes deletions so we never lint a removed file.
+    """
+    output = subprocess.check_output(
+        ["git", "diff", "--staged", "--name-only", "--diff-filter=d", "--"]
+        + [f"*{ext}" for ext in TIDY_EXTENSIONS],
+        text=True,
+        cwd=repo_root,
+    )
+    return [repo_root / rel for rel in output.splitlines() if rel]
+
+
 def main():
     if not os.environ.get("TIDY"):
         return 0
 
-    files = sys.argv[1:]
+    repo_root = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"],
+            cwd=Path(__file__).parent,
+            text=True,
+        ).strip()
+    )
+
+    files = staged_files(repo_root)
     if not files:
         return 0
 
@@ -52,13 +77,6 @@ def main():
         )
         return 1
 
-    repo_root = Path(
-        subprocess.check_output(
-            ["git", "rev-parse", "--show-toplevel"],
-            cwd=Path(__file__).parent,
-            text=True,
-        ).strip()
-    )
     build_dir = find_build_dir(repo_root)
     if not build_dir:
         print(
@@ -69,7 +87,16 @@ def main():
         return 1
 
     result = subprocess.run(
-        [run_clang_tidy, "-quiet", "-p", str(build_dir), "-fix", "-allow-no-checks"]
+        [
+            run_clang_tidy,
+            "-quiet",
+            "-p",
+            build_dir,
+            "-j",
+            str(os.cpu_count()),
+            "-fix",
+            "-allow-no-checks",
+        ]
         + files
     )
     return result.returncode

--- a/bin/pre-commit/clang_tidy_check.py
+++ b/bin/pre-commit/clang_tidy_check.py
@@ -137,8 +137,6 @@ def main():
                 "-quiet",
                 "-p",
                 build_dir,
-                "-j",
-                str(os.cpu_count()),
                 "-export-fixes",
                 fixes_dir,
                 "-allow-no-checks",

--- a/bin/pre-commit/clang_tidy_check.py
+++ b/bin/pre-commit/clang_tidy_check.py
@@ -4,15 +4,26 @@
 The script determines the staged files itself (see `pass_filenames: false` in
 .pre-commit-config.yaml) so run-clang-tidy is run once and handles parallelism
 internally: pre-commit would otherwise split the files across parallel hook
-invocations that race when `--fix` edits a shared header.
+invocations that race when fixes edit a shared header.
+
+Fixes are collected with `-export-fixes` and applied by clang-apply-replacements
+in a separate step rather than with run-clang-tidy's `-fix`. The `add_module`
+build isolates each module's headers behind a per-module symlink directory
+(build/modules/<module>/...), so a header reachable from several translation
+units is referenced through different paths that all resolve to the same source
+file. clang-apply-replacements deduplicates identical replacements by their
+literal path, so those paths must be canonicalised to the real source path
+first; otherwise the same fix is applied once per path and corrupts the header.
 """
 
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 CLANG_TIDY_VERSION = 22
@@ -22,9 +33,14 @@ CLANG_TIDY_VERSION = 22
 # compile_commands.json entry). `.ipp` fragments have no entry and are skipped.
 TIDY_EXTENSIONS = {".cpp", ".h", ".hpp"}
 
+# A single-quoted `FilePath:` entry in an -export-fixes YAML file, allowing the
+# `- ` marker that precedes it inside a `Replacements:` sequence. clang-tidy
+# emits paths single-quoted and doubles any embedded quote per YAML rules.
+FILEPATH_RE = re.compile(r"^(\s*(?:-\s+)?FilePath:\s*)'((?:[^']|'')*)'\s*$")
 
-def find_run_clang_tidy() -> str | None:
-    for candidate in (f"run-clang-tidy-{CLANG_TIDY_VERSION}", "run-clang-tidy"):
+
+def find_tool(name: str) -> str | None:
+    for candidate in (f"{name}-{CLANG_TIDY_VERSION}", name):
         if path := shutil.which(candidate):
             return path
     return None
@@ -52,6 +68,25 @@ def staged_files(repo_root: Path) -> list[Path]:
     return [repo_root / rel for rel in output.splitlines() if rel]
 
 
+def canonicalize_fix_paths(fixes_dir: Path) -> None:
+    """Rewrite every `FilePath` in the exported fixes to its real source path.
+
+    A header included through a module's isolation symlink is recorded under that
+    symlink's path; collapsing all paths to the same real file lets
+    clang-apply-replacements recognise the per-translation-unit duplicates and
+    apply each fix once.
+    """
+    for yaml in fixes_dir.glob("*.yaml"):
+        lines = []
+        for line in yaml.read_text().splitlines():
+            if m := FILEPATH_RE.match(line):
+                path = m.group(2).replace("''", "'")
+                real = os.path.realpath(path).replace("'", "''")
+                line = f"{m.group(1)}'{real}'"
+            lines.append(line)
+        yaml.write_text("\n".join(lines) + "\n")
+
+
 def main():
     if not os.environ.get("TIDY"):
         return 0
@@ -68,11 +103,20 @@ def main():
     if not files:
         return 0
 
-    run_clang_tidy = find_run_clang_tidy()
-    if not run_clang_tidy:
+    run_clang_tidy = find_tool("run-clang-tidy")
+    clang_apply_replacements = find_tool("clang-apply-replacements")
+    missing = [
+        name
+        for name, path in (
+            ("run-clang-tidy", run_clang_tidy),
+            ("clang-apply-replacements", clang_apply_replacements),
+        )
+        if not path
+    ]
+    if missing:
         print(
-            f"clang-tidy check failed: TIDY is enabled but neither "
-            f"'run-clang-tidy-{CLANG_TIDY_VERSION}' nor 'run-clang-tidy' was found in PATH.",
+            f"clang-tidy check failed: TIDY is enabled but {' and '.join(missing)} "
+            f"was not found in PATH (tried the '-{CLANG_TIDY_VERSION}' suffix too).",
             file=sys.stderr,
         )
         return 1
@@ -86,20 +130,25 @@ def main():
         )
         return 1
 
-    result = subprocess.run(
-        [
-            run_clang_tidy,
-            "-quiet",
-            "-p",
-            build_dir,
-            "-j",
-            str(os.cpu_count()),
-            "-fix",
-            "-allow-no-checks",
-        ]
-        + files
-    )
-    return result.returncode
+    with tempfile.TemporaryDirectory() as fixes_dir:
+        result = subprocess.run(
+            [
+                run_clang_tidy,
+                "-quiet",
+                "-p",
+                build_dir,
+                "-j",
+                str(os.cpu_count()),
+                "-export-fixes",
+                fixes_dir,
+                "-allow-no-checks",
+            ]
+            + files
+        )
+        canonicalize_fix_paths(Path(fixes_dir))
+        applied = subprocess.run([clang_apply_replacements, fixes_dir])
+
+    return result.returncode or applied.returncode
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This restores part of the behaviour changed in https://github.com/XRPLF/rippled/pull/7670.
But I implemented it more simply - `subprocess.check_output` is called with `text=True` and a filter for files.
Also, pathlib.Path is used directly where possible

**Next section explains why there is deduplication**

## Why deduplication is needed

`run-clang-tidy` lints each translation unit independently and, with `--fix`,
applies every fix immediately. The `add_module` build isolates each module's
headers behind a per-module symlink directory (`build/modules/<module>/…`), so a
single header file is reachable through more than one path: its own
`verify_headers` TU sees it at the real source path (`include/xrpl/…/Foo.h`),
while every `.cpp` that includes it sees it through the module symlink
(`build/modules/…/Foo.h`).

When such a header is edited alongside a source file that includes it, both paths
end up in the same lint run. `clang-apply-replacements` deduplicates identical
fixes only by their **literal** path string — it treats the source path and the
symlink path as two different files — so it applies the *same* fix once per path.
Because both paths resolve to one physical file, the edit lands twice and
corrupts the header (e.g. `if (a) { {`).

The hook therefore exports fixes instead of applying them, rewrites every
`FilePath` to its real (symlink-resolved) path, and only then runs
`clang-apply-replacements`. Once all paths are canonical, the per-path duplicates
become byte-identical, dedup collapses them, and each fix is applied exactly
once.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
