### PR TITLE
chore: Bump version to 3.3.0-rc1

### DIFF
--- a/src/libxrpl/protocol/BuildInfo.cpp
+++ b/src/libxrpl/protocol/BuildInfo.cpp
@@ -23,7 +23,7 @@ namespace {
 //------------------------------------------------------------------------------
 // clang-format off
 // NOLINTNEXTLINE(readability-identifier-naming)
-char const* const versionString = "3.3.0-b1"
+char const* const versionString = "3.3.0-rc1"
     // clang-format on
     ;
 


### PR DESCRIPTION
This change sets the version to `3.3.0-rc1` in anticipation of the final release.