### PR TITLE
ci: Fix workflow launch on matrix-unrelated labels

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -25,18 +25,11 @@ on:
       - unlabeled
 
 concurrency:
-  # Use a per-ref group so a newer run (a push, or a change to a label below)
-  # supersedes the in-progress one for that ref. Label events we don't act on get
-  # their own unique group (per run id) instead, keeping them out of the shared
-  # group so real builds keep running. Keep this list in sync with `should-run`.
-  group: >-
-    ${{ github.workflow }}-${{ github.ref }}${{
-      ((github.event.action == 'labeled' || github.event.action == 'unlabeled')
-      && github.event.label.name != 'Ready to merge'
-      && github.event.label.name != 'DraftRunCI'
-      && github.event.label.name != 'Full CI build')
-      && format('-{0}', github.run_id) || ''
-    }}
+  # A single per-ref group with cancel-in-progress means any newer run (a push
+  # or a label change) supersedes the in-progress one for that ref. Keeping
+  # exactly one authoritative run per ref ensures a fast do-nothing run can never
+  # mask a real build's checks.
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 defaults:
@@ -44,21 +37,17 @@ defaults:
     shell: bash
 
 jobs:
-  # This job determines whether the rest of the workflow should run. It runs
-  # when the PR is not a draft (which should also cover merge-group) or has the
-  # 'DraftRunCI' or 'Full CI build' label. For label events it only runs when the
-  # label added or removed is one we act on ('Ready to merge', 'DraftRunCI' or
-  # 'Full CI build'), so unrelated label changes do not trigger a redundant run.
+  # This job determines whether the rest of the workflow should run at all,
+  # based on the current set of labels: it runs when the PR is not a draft
+  # (which should also cover merge-group) or has the 'DraftRunCI' or
+  # 'Full CI build' label. Whether a build then happens, and whether it is the
+  # minimal or full matrix, is decided further below and in the strategy matrix.
   should-run:
     if: >-
       ${{
-        ((github.event.action != 'labeled' && github.event.action != 'unlabeled')
-          || github.event.label.name == 'Ready to merge'
-          || github.event.label.name == 'DraftRunCI'
-          || github.event.label.name == 'Full CI build')
-        && (!github.event.pull_request.draft
-          || contains(github.event.pull_request.labels.*.name, 'DraftRunCI')
-          || contains(github.event.pull_request.labels.*.name, 'Full CI build'))
+        !github.event.pull_request.draft
+        || contains(github.event.pull_request.labels.*.name, 'DraftRunCI')
+        || contains(github.event.pull_request.labels.*.name, 'Full CI build')
       }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Fix workflow launch so matrix-unrelated labels can no longer hide or drop a PR's build. Decisions are now driven purely by the current label set, and a single concurrency group guarantees one authoritative run per ref.

## High Level Overview of Change

- **Concurrency:** collapsed to a single per-ref group with `cancel-in-progress`, so any newer run (push or label change) supersedes the in-progress one. Removes the coexisting-run window where a fast do-nothing run could mask a real build's checks.
- **Decisions from the current label set only:** dropped all `github.event.action` / `github.event.label.name` logic.
  - *Run at all?* — `should-run` runs unless the PR is a draft without `DraftRunCI`/`Full CI build`.
  - *Minimal or full?* — full matrix when `Ready to merge`/`Full CI build` is present, minimal otherwise.
- **Trade-off:** an unrelated label now cancels/re-triggers the build rather than doing nothing — the deliberate cost of never masking real results

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
