### PR TITLE
feat: Export ledger name spaces via server_definitions

### DIFF
--- a/include/xrpl/protocol/Indexes.h
+++ b/include/xrpl/protocol/Indexes.h
@@ -17,10 +17,45 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <map>
 #include <set>
+#include <string>
 #include <utility>
 
 namespace xrpl {
+
+/**
+ * Type-specific prefix for calculating ledger indices.
+ *
+ * The identifier for a given object within the ledger is calculated based
+ * on some object-specific parameters. To ensure that different types of
+ * objects have different indices, even if they happen to use the same set
+ * of parameters, we use "tagged hashing" by adding a type-specific prefix.
+ *
+ * The name spaces are listed in detail/ledger_name_spaces.macro.
+ */
+#pragma push_macro("LEDGER_NAME_SPACE")
+#undef LEDGER_NAME_SPACE
+#pragma push_macro("LEDGER_NAME_SPACE_DEPRECATED")
+#undef LEDGER_NAME_SPACE_DEPRECATED
+
+#define LEDGER_NAME_SPACE(name, value) name = (value),
+#define LEDGER_NAME_SPACE_DEPRECATED(name, value) name [[deprecated]] = (value),
+
+enum class LedgerNameSpace : std::uint16_t {
+#include <xrpl/protocol/detail/ledger_name_spaces.macro>
+};
+
+#undef LEDGER_NAME_SPACE_DEPRECATED
+#pragma pop_macro("LEDGER_NAME_SPACE_DEPRECATED")
+#undef LEDGER_NAME_SPACE
+#pragma pop_macro("LEDGER_NAME_SPACE")
+
+/**
+ * The name->value map of active (non-deprecated) ledger name spaces.
+ */
+std::map<std::string, std::uint16_t> const&
+ledgerNameSpaceMap();
 
 class SeqProxy;
 /**

--- a/include/xrpl/protocol/detail/ledger_name_spaces.macro
+++ b/include/xrpl/protocol/detail/ledger_name_spaces.macro
@@ -1,0 +1,59 @@
+#if !defined(LEDGER_NAME_SPACE)
+#error "undefined macro: LEDGER_NAME_SPACE"
+#endif
+#if !defined(LEDGER_NAME_SPACE_DEPRECATED)
+#error "undefined macro: LEDGER_NAME_SPACE_DEPRECATED"
+#endif
+
+// Active ledger name spaces.
+//
+// @note These values are part of the protocol and *CANNOT* be arbitrarily
+//       changed. If they were, on-ledger objects may no longer be able to
+//       be located or addressed.
+//
+//       Additions to this list are OK, but changing existing entries to
+//       assign them a different values should never be needed.
+//
+//       Entries that are removed should be moved to the deprecated list
+//       below to prevent accidental reuse.
+LEDGER_NAME_SPACE(Account, 'a')
+LEDGER_NAME_SPACE(DirNode, 'd')
+LEDGER_NAME_SPACE(TrustLine, 'r')
+LEDGER_NAME_SPACE(Offer, 'o')
+LEDGER_NAME_SPACE(OwnerDir, 'O')
+LEDGER_NAME_SPACE(BookDir, 'B')
+LEDGER_NAME_SPACE(SkipList, 's')
+LEDGER_NAME_SPACE(Escrow, 'u')
+LEDGER_NAME_SPACE(Amendments, 'f')
+LEDGER_NAME_SPACE(FeeSettings, 'e')
+LEDGER_NAME_SPACE(Ticket, 'T')
+LEDGER_NAME_SPACE(SignerList, 'S')
+LEDGER_NAME_SPACE(XRPPaymentChannel, 'x')
+LEDGER_NAME_SPACE(Check, 'C')
+LEDGER_NAME_SPACE(DepositPreauth, 'p')
+LEDGER_NAME_SPACE(DepositPreauthCredentials, 'P')
+LEDGER_NAME_SPACE(NegativeUnl, 'N')
+LEDGER_NAME_SPACE(NftokenOffer, 'q')
+LEDGER_NAME_SPACE(NftokenBuyOffers, 'h')
+LEDGER_NAME_SPACE(NftokenSellOffers, 'i')
+LEDGER_NAME_SPACE(Amm, 'A')
+LEDGER_NAME_SPACE(Bridge, 'H')
+LEDGER_NAME_SPACE(XchainClaimId, 'Q')
+LEDGER_NAME_SPACE(XchainCreateAccountClaimId, 'K')
+LEDGER_NAME_SPACE(Did, 'I')
+LEDGER_NAME_SPACE(Oracle, 'R')
+LEDGER_NAME_SPACE(MPTokenIssuance, '~')
+LEDGER_NAME_SPACE(MPToken, 't')
+LEDGER_NAME_SPACE(Credential, 'D')
+LEDGER_NAME_SPACE(PermissionedDomain, 'm')
+LEDGER_NAME_SPACE(Delegate, 'E')
+LEDGER_NAME_SPACE(Vault, 'V')
+LEDGER_NAME_SPACE(LoanBroker, 'l')  // lower-case L
+LEDGER_NAME_SPACE(Loan, 'L')
+LEDGER_NAME_SPACE(Sponsorship, '>')
+
+// No longer used or supported. Left here to reserve the space to avoid
+// accidental reuse, and intentionally not exported to clients.
+LEDGER_NAME_SPACE_DEPRECATED(Contract, 'c')
+LEDGER_NAME_SPACE_DEPRECATED(Generator, 'g')
+LEDGER_NAME_SPACE_DEPRECATED(Nickname, 'n')

--- a/include/xrpl/protocol/jss.h
+++ b/include/xrpl/protocol/jss.h
@@ -350,6 +350,7 @@ JSS(LEDGER_ENTRY_TYPES);             // out: RPC server_definitions
                                      // matches definitions.json format
 JSS(LEDGER_ENTRY_FLAGS);             // out: RPC server_definitions
 JSS(LEDGER_ENTRY_FORMATS);           // out: RPC server_definitions
+JSS(LEDGER_NAME_SPACES);             // out: RPC server_definitions
 JSS(levels);                         // LogLevels
 JSS(limit);                       // in/out: AccountTx*, AccountOffers, AccountLines, AccountObjects
                                   // in: LedgerData, BookOffers

--- a/src/libxrpl/protocol/Indexes.cpp
+++ b/src/libxrpl/protocol/Indexes.cpp
@@ -26,7 +26,9 @@
 #include <array>
 #include <cstdint>
 #include <cstring>
+#include <map>
 #include <set>
+#include <string>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -50,66 +52,28 @@ std::array<KeyletDesc<AccountID const&>, 6> const kDirectAccountKeylets{
       .includeInTests = true},
      {.function = &keylet::did, .expectedLEName = jss::DID, .includeInTests = true}}};
 
-/**
- * Type-specific prefix for calculating ledger indices.
- *
- * The identifier for a given object within the ledger is calculated based
- * on some object-specific parameters. To ensure that different types of
- * objects have different indices, even if they happen to use the same set
- * of parameters, we use "tagged hashing" by adding a type-specific prefix.
- *
- * @note These values are part of the protocol and *CANNOT* be arbitrarily
- *       changed. If they were, on-ledger objects may no longer be able to
- *       be located or addressed.
- *
- *       Additions to this list are OK, but changing existing entries to
- *       assign them a different values should never be needed.
- *
- *       Entries that are removed should be moved to the bottom of the enum
- *       and marked as [[deprecated]] to prevent accidental reuse.
- */
-enum class LedgerNameSpace : std::uint16_t {
-    Account = 'a',
-    DirNode = 'd',
-    TrustLine = 'r',
-    Offer = 'o',
-    OwnerDir = 'O',
-    BookDir = 'B',
-    SkipList = 's',
-    Escrow = 'u',
-    Amendments = 'f',
-    FeeSettings = 'e',
-    Ticket = 'T',
-    SignerList = 'S',
-    XRPPaymentChannel = 'x',
-    Check = 'C',
-    DepositPreauth = 'p',
-    DepositPreauthCredentials = 'P',
-    NegativeUnl = 'N',
-    NftokenOffer = 'q',
-    NftokenBuyOffers = 'h',
-    NftokenSellOffers = 'i',
-    Amm = 'A',
-    Bridge = 'H',
-    XchainClaimId = 'Q',
-    XchainCreateAccountClaimId = 'K',
-    Did = 'I',
-    Oracle = 'R',
-    MPTokenIssuance = '~',
-    MPToken = 't',
-    Credential = 'D',
-    PermissionedDomain = 'm',
-    Delegate = 'E',
-    Vault = 'V',
-    LoanBroker = 'l',  // lower-case L
-    Loan = 'L',
-    Sponsorship = '>',
+std::map<std::string, std::uint16_t> const&
+ledgerNameSpaceMap()
+{
+#pragma push_macro("LEDGER_NAME_SPACE")
+#undef LEDGER_NAME_SPACE
+#pragma push_macro("LEDGER_NAME_SPACE_DEPRECATED")
+#undef LEDGER_NAME_SPACE_DEPRECATED
 
-    // No longer used or supported. Left here to reserve the space to avoid accidental reuse.
-    Contract [[deprecated]] = 'c',
-    Generator [[deprecated]] = 'g',
-    Nickname [[deprecated]] = 'n',
-};
+#define LEDGER_NAME_SPACE(name, value) {#name, static_cast<std::uint16_t>(LedgerNameSpace::name)},
+#define LEDGER_NAME_SPACE_DEPRECATED(name, value)
+
+    static std::map<std::string, std::uint16_t> const kMap{
+#include <xrpl/protocol/detail/ledger_name_spaces.macro>
+    };
+
+#undef LEDGER_NAME_SPACE_DEPRECATED
+#pragma pop_macro("LEDGER_NAME_SPACE_DEPRECATED")
+#undef LEDGER_NAME_SPACE
+#pragma pop_macro("LEDGER_NAME_SPACE")
+
+    return kMap;
+}
 
 template <class... Args>
 static uint256

--- a/src/test/rpc/ServerDefinitions_test.cpp
+++ b/src/test/rpc/ServerDefinitions_test.cpp
@@ -31,6 +31,7 @@ public:
             BEAST_EXPECT(result[jss::result][jss::status] == "success");
             BEAST_EXPECT(result[jss::result].isMember(jss::FIELDS));
             BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_TYPES));
+            BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_NAME_SPACES));
             BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_RESULTS));
             BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_TYPES));
             BEAST_EXPECT(result[jss::result].isMember(jss::TYPES));
@@ -106,6 +107,18 @@ public:
                 result[jss::result][jss::TRANSACTION_RESULTS]["tecDIR_FULL"].asUInt() == 121);
             BEAST_EXPECT(result[jss::result][jss::TRANSACTION_TYPES]["Payment"].asUInt() == 0);
             BEAST_EXPECT(result[jss::result][jss::TYPES]["AccountID"].asUInt() == 8);
+
+            // test the properties of the LEDGER_NAME_SPACES section
+            {
+                json::Value const& nameSpaces = result[jss::result][jss::LEDGER_NAME_SPACES];
+                BEAST_EXPECT(nameSpaces["Account"].asUInt() == 97);  // 'a'
+                BEAST_EXPECT(nameSpaces["Vault"].asUInt() == 86);    // 'V'
+
+                // deprecated name spaces are not exported
+                BEAST_EXPECT(!nameSpaces.isMember("Contract"));
+                BEAST_EXPECT(!nameSpaces.isMember("Generator"));
+                BEAST_EXPECT(!nameSpaces.isMember("Nickname"));
+            }
 
             // test the properties of the LEDGER_ENTRY_FLAGS section
             {
@@ -441,6 +454,7 @@ public:
                 BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_ENTRY_TYPES));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_ENTRY_FLAGS));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_ENTRY_FORMATS));
+                BEAST_EXPECT(!result[jss::result].isMember(jss::LEDGER_NAME_SPACES));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::TRANSACTION_RESULTS));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::TRANSACTION_TYPES));
                 BEAST_EXPECT(!result[jss::result].isMember(jss::TRANSACTION_FLAGS));
@@ -464,6 +478,7 @@ public:
                 BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_TYPES));
                 BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_FLAGS));
                 BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_ENTRY_FORMATS));
+                BEAST_EXPECT(result[jss::result].isMember(jss::LEDGER_NAME_SPACES));
                 BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_RESULTS));
                 BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_TYPES));
                 BEAST_EXPECT(result[jss::result].isMember(jss::TRANSACTION_FLAGS));
@@ -486,6 +501,7 @@ public:
               jss::LEDGER_ENTRY_FLAGS,
               jss::LEDGER_ENTRY_FORMATS,
               jss::LEDGER_ENTRY_TYPES,
+              jss::LEDGER_NAME_SPACES,
               jss::TRANSACTION_FLAGS,
               jss::TRANSACTION_FORMATS,
               jss::TRANSACTION_RESULTS,

--- a/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp
+++ b/src/xrpld/rpc/handlers/server_info/ServerDefinitions.cpp
@@ -6,6 +6,7 @@
 #include <xrpl/json/json_value.h>
 #include <xrpl/json/json_writer.h>
 #include <xrpl/protocol/ErrorCodes.h>
+#include <xrpl/protocol/Indexes.h>
 #include <xrpl/protocol/LedgerFormats.h>
 #include <xrpl/protocol/SField.h>
 #include <xrpl/protocol/TER.h>
@@ -356,6 +357,12 @@ ServerDefinitions::ServerDefinitions() : defs_{json::ValueType::Object}
     for (auto const& [name, value] : getAsfFlagMap())
     {
         defs_[jss::ACCOUNT_SET_FLAGS][name] = value;
+    }
+
+    defs_[jss::LEDGER_NAME_SPACES] = json::ValueType::Object;
+    for (auto const& [name, value] : ledgerNameSpaceMap())
+    {
+        defs_[jss::LEDGER_NAME_SPACES][name] = value;
     }
 
     // generate hash


### PR DESCRIPTION
<!--
This PR template helps you to write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR.  This avoids unnecessary redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

Adds a `LEDGER_NAME_SPACES` section to the `server_definitions` RPC response. It exports the name → value map of the `LedgerNameSpace` tagged-hash prefixes so clients can compute keylets offline instead of hard-coding the ASCII prefixes or round-tripping to a server.

### Context of Change

Clients that want to derive ledger object indexes (keylets) locally need the type-specific prefixes used in the tagged hashing. Today those only exist as a private enum in `Indexes.cpp`, so every client library carries its own copy and has to chase new amendments by hand. `server_definitions` already exports fields, ledger entry types, transaction types, etc. for exactly this reason — this just extends it to name spaces.

The enum moves from `Indexes.cpp` into `Indexes.h` and is generated from a single X-macro list (`detail/ledger_name_spaces.macro`). The same list co-generates `ledgerNameSpaceMap()`, so the enum and the exported map cannot drift — adding a name space in one place updates both. Deprecated name spaces (`Contract`, `Generator`, `Nickname`) stay in the list to reserve their values but are intentionally NOT exported, since keylets should never be computed for retired spaces.

The alternative was exporting a hand-written map next to the enum, but that's two lists to keep in sync and the whole point is to stop copies drifting.

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to PR.
-->
