### PR TITLE
chore: Add CODEOWNERS for CI-related changes

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,4 @@
 # By default, anyone can review changes.
-*
 
 # The CI tooling team should review changes to the CI configuration.
 /.github/ @XRPLF/ci-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # By default, anyone can review changes.
 
 # The CI tooling team should review changes to the CI configuration.
-/.github/ @xrplf/ci-tooling
+/.github/ @XRPLF/ci-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# By default, anyone can review changes.
+*
+
+# The CI tooling team should review changes to the CI configuration.
+/.github/ @XRPLF/ci-tooling

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # By default, anyone can review changes.
 
 # The CI tooling team should review changes to the CI configuration.
-/.github/ @XRPLF/ci-tooling
+/.github/ @xrplf/ci-tooling


### PR DESCRIPTION
## High Level Overview of Change

This change allows anyone to review any change by default, but requires the `XRPLF/ci-tooling` team to review CI-related changes.

### Context of Change

Changes affecting CI, such as changes to the workflows and actions, or Dependabot updates, can be best reviewed by those who are familiar with GitHub Actions.