### PR TITLE
ci: Pre-commit clang-tidy checks for the build directory at the top level

### DIFF
--- a/bin/pre-commit/clang_tidy_check.py
+++ b/bin/pre-commit/clang_tidy_check.py
@@ -94,7 +94,6 @@ def main():
     repo_root = Path(
         subprocess.check_output(
             ["git", "rev-parse", "--show-toplevel"],
-            cwd=Path(__file__).parent,
             text=True,
         ).strip()
     )


### PR DESCRIPTION
## High Level Overview of Change

This PR fixes the clang-tidy pre-commit check to look for the build folders at the top level, not in `bin/pre-commit`.

### Context of Change

Previously:
```
clang-tidy (enable with: TIDY=1)..............................................Failed
- hook id: clang-tidy
- exit code: 1

find_build_dir: candidate:  /Users/mvadari/Documents/rippled-all/copilot/bin/pre-commit/.build  <--- log line added by me
find_build_dir: candidate:  /Users/mvadari/Documents/rippled-all/copilot/bin/pre-commit/build  <--- log line added by me
clang-tidy check failed: no build directory with compile_commands.json found (looked for .build/ and build/)
```

### API Impact

N/A