### PR TITLE
style: Make clang-tidy format files using clang-format rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -75,6 +75,8 @@ Checks: "-*,
 # readability-static-accessed-through-instance,        # this check is probably unnecessary. It makes the code less readable
 # ---
 
+FormatStyle: file
+
 CheckOptions:
   bugprone-unsafe-functions.ReportMoreUnsafeFunctions: true
   bugprone-unused-return-value.CheckedReturnTypes: ::std::error_code;::std::error_condition;::std::errc

--- a/.github/workflows/reusable-clang-tidy.yml
+++ b/.github/workflows/reusable-clang-tidy.yml
@@ -95,7 +95,7 @@ jobs:
           TARGETS: ${{ needs.determine-files.outputs.need_full_run != 'true' && needs.determine-files.outputs.cpp_changed_files || 'include src tests' }}
         run: |
           set -o pipefail
-          run-clang-tidy -j ${{ steps.nproc.outputs.nproc }} -p "${BUILD_DIR}" -quiet -fix -allow-no-checks ${TARGETS} 2>&1 | tee "${OUTPUT_FILE}"
+          run-clang-tidy -j ${{ steps.nproc.outputs.nproc }} -p "${BUILD_DIR}" -quiet -fix -format -allow-no-checks ${TARGETS} 2>&1 | tee "${OUTPUT_FILE}"
 
       - name: Print filtered clang-tidy errors
         if: ${{ steps.run_clang_tidy.outcome != 'success' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -348,11 +348,13 @@ run-clang-tidy -p build -allow-no-checks src tests
 ```
 
 This will check all source files in the `src`, `include` and `tests` directories using the compile commands from your `build` directory.
-If you wish to automatically fix whatever clang-tidy finds _and_ is capable of fixing, add `-fix` to the above command:
+If you wish to automatically fix whatever clang-tidy finds _and_ is capable of fixing, add `-fix -format` to the above command:
 
 ```
-run-clang-tidy -p build -quiet -fix -allow-no-checks src tests
+run-clang-tidy -p build -quiet -fix -format -allow-no-checks src tests
 ```
+
+`-format` reformats the fixed code with [`.clang-format`](./.clang-format); without it the fixes are inserted in LLVM style and the `clang-format` hook rewrites them afterwards.
 
 ## Contracts and instrumentation
 

--- a/bin/pre-commit/clang_tidy_check.py
+++ b/bin/pre-commit/clang_tidy_check.py
@@ -144,7 +144,11 @@ def main():
             + files
         )
         canonicalize_fix_paths(Path(fixes_dir))
-        applied = subprocess.run([clang_apply_replacements, fixes_dir])
+        # `FormatStyle` in .clang-tidy does not reach this path,
+        # so ask for the repository style here.
+        applied = subprocess.run(
+            [clang_apply_replacements, "--format", "--style=file", fixes_dir]
+        )
 
     return result.returncode or applied.returncode
 


### PR DESCRIPTION
<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

## Problem

`clang-tidy` inserts its fixes as raw text: `--format-style` defaults to `none`, so a fix
like `readability-braces-around-statements` produces LLVM-style attached braces and an
unindented closing brace. The `clang-format` hook then rewrites them into the project's
style, so every auto-fixed file gets touched twice and CI's uploaded clang-tidy diff shows
code that does not match what would actually be committed.

## Change

Point every clang-tidy fix path at `.clang-format`:

- `.clang-tidy` — `FormatStyle: file`, for `clang-tidy --fix` run directly or from an editor.
- `bin/pre-commit/clang_tidy_check.py` — `clang-apply-replacements --format --style=file`.
  `FormatStyle` does not reach this path: with `-export-fixes` clang-tidy never applies
  anything, and formatting happens when the replacements are applied.
- `.github/workflows/reusable-clang-tidy.yml` — `run-clang-tidy -fix -format`. Same reason:
  `run-clang-tidy -fix` shells out to `clang-apply-replacements` internally.
- `CONTRIBUTING.md` — documented `-fix -format` in the manual invocation.

### Testing

A torture TU was built inside a real file (`src/libxrpl/basics/mulDiv.cpp`), starting
clang-format clean so any post-tidy difference is attributable to the tidy step alone. It
triggers 19 fixes across 9 checks, including structural ones (`readability-else-after-return`,
`modernize-loop-convert`) and fixes that push lines past the 100-column limit
(`readability-implicit-bool-conversion`).

Each fix path was run on that TU, then measured: **how many lines does `clang-format` still
have to rewrite afterwards?** Zero means the tidy step already produced conforming code.

| Fix path | Where it is used | Lines left for `clang-format` (before → after) |
| --- | --- | --- |
| `clang-tidy --fix` | run by hand or from an editor | 42 → **0** |
| `run-clang-tidy -fix` | the CI workflow | 42 → **0** |
| `-export-fixes` + `clang-apply-replacements` | inside the pre-commit hook | 42 → **0** |
| `TIDY=1 prek run clang-tidy` | the hook, end to end | 42 → **0** |

All four paths apply the same 19 fixes before and after; only the formatting of the result
changes. After the change, `prek run clang-format` reports `Passed` on the hook's output, so
the two hooks no longer take turns rewriting the same lines.

Also verified:

- **Fixes are unchanged.** All six outputs (three paths, before and after) normalise to
  byte-identical content, so `-format` only front-loads what `clang-format` would do anyway.
- **Header dedup still works.** A header fixed through three translation units (staged header
  plus two includers, with `build/modules/` symlinks live) gets each fix applied exactly once,
  byte-identical to the single-TU result, and compiles.
- **No scope creep.** Only lines a fix touched are reformatted; a deliberately misformatted
  function elsewhere in the file was left untouched for the `clang-format` hook.
- **Convergence.** 53 → 11 → 1 replacements over three passes, clang-format clean at each step.
<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
