### PR TITLE
fix: Add missing value_type to JSON iterators

### DIFF
--- a/include/xrpl/json/json_value.h
+++ b/include/xrpl/json/json_value.h
@@ -623,6 +623,7 @@ class ValueConstIterator : public ValueIteratorBase
 public:
     using size_t = unsigned int;
     using difference_type = int;
+    using value_type = Value const;
     using reference = Value const&;
     using pointer = Value const*;
     using SelfType = ValueConstIterator;
@@ -687,6 +688,7 @@ class ValueIterator : public ValueIteratorBase
 public:
     using size_t = unsigned int;
     using difference_type = int;
+    using value_type = Value;
     using reference = Value&;
     using pointer = Value*;
     using SelfType = ValueIterator;


### PR DESCRIPTION
## High Level Overview of Change

ValueConstIterator and ValueIterator lacked the value_type typedef required for std::iterator_traits deduction in C++20. GCC 13's STL correctly diagnoses this when the iterators are used with algorithms like std::all_of.

This PR adds the missing typedefs.

### Context of Change

PR #7772 refactors `src/xrpld/rpc/detail/RPCCall.cpp` to `std::all_of` instead of an iterator-based for loop. This changed the contract required of the JSON ValueIterator such that it now [strictly speaking] needed to fulfill the requirements for `Cpp17InputIterator`. It doesn't actually do so in its current form. This turned out not to be fatal on the compiler versions used in CI, but for GCC 13 it causes a build break.

### API Impact

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)
