### PR TITLE
fix: Validate the log_level severity and partition parameters

### DIFF
--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,6 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
+- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
 
 ## XRP Ledger server version 3.1.0
 

--- a/API-CHANGELOG.md
+++ b/API-CHANGELOG.md
@@ -53,7 +53,7 @@ This section contains changes targeting a future version.
 - `submit`: The `fail_hard` field now returns an error if the value is not a boolean. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - `subscribe`: The `taker` field in the `books` array now returns `actMalformed` instead of `badIssuer` if the value is not a valid account. [#6529](https://github.com/XRPLF/rippled/pull/6529)
 - Fixed a bug in `Forwarded` HTTP header parsing where the extracted IP address could be incorrect when no comma or semicolon delimiter follows the address. This could cause the server to misidentify a client's IP address when operating behind a reverse proxy. [#6529](https://github.com/XRPLF/rippled/pull/6529)
-- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#NNNN](https://github.com/XRPLF/rippled/pull/NNNN)
+- `log_level`: The `severity` and `partition` fields now return `invalidParams` if the value is not a string, and `partition` also rejects the empty string. Previously, arrays and objects returned an `internal` error, and numbers, booleans, and `null` were silently coerced — for `partition` this permanently created a log partition named after the coerced value. [#7922](https://github.com/XRPLF/rippled/pull/7922)
 
 ## XRP Ledger server version 3.1.0
 

--- a/src/test/rpc/LogLevel_test.cpp
+++ b/src/test/rpc/LogLevel_test.cpp
@@ -1,0 +1,232 @@
+#include <test/jtx/Env.h>
+
+#include <xrpl/beast/unit_test/suite.h>
+#include <xrpl/json/json_value.h>
+#include <xrpl/protocol/jss.h>
+
+#include <boost/container/static_vector.hpp>
+
+#include <array>
+#include <string>
+#include <utility>
+
+namespace xrpl {
+
+class LogLevel_test : public beast::unit_test::Suite
+{
+    // The bad values shared by both parameters. Arrays and objects make
+    // json::Value::asString() throw; the scalars are silently stringified by
+    // it, so without a type check they reach the handler as "42", "1.500000",
+    // "true" and "". Capacity leaves room for one parameter-specific value.
+    static boost::container::static_vector<json::Value, 7>
+    badValues()
+    {
+        json::Value objValue{json::ValueType::Object};
+        objValue["nope"] = 0;
+        json::Value arrValue{json::ValueType::Array};
+        arrValue.append("warn");
+
+        return {
+            json::Value{42},    // int
+            json::Value{1.5},   // real
+            json::Value{true},  // bool
+            json::Value{},      // null
+            objValue,
+            arrValue,
+        };
+    }
+
+    // The names the bad scalars above would be stringified into if they were
+    // not rejected. "" covers both the null and the empty-string partition.
+    static constexpr std::array<char const*, 4> kJunkPartitions{
+        "42",
+        "1.500000",
+        "true",
+        "",
+    };
+
+    // A partition no other subsystem writes to, so changing its threshold has
+    // no effect on how much this suite logs.
+    static constexpr char const* kTestPartition = "LogLevelTestPartition";
+
+    static json::Value
+    levels(test::jtx::Env& env)
+    {
+        return env.client().invoke("log_level")[jss::result][jss::levels];
+    }
+
+    void
+    testGetLevels()
+    {
+        testcase("Get levels");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // Omitting the severity lists the current thresholds rather than
+        // setting one.
+        auto const result = env.client().invoke("log_level")[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(result[jss::status] == "success");
+        BEAST_EXPECT(result[jss::levels].isObject());
+        BEAST_EXPECT(result[jss::levels].isMember(jss::base));
+    }
+
+    void
+    testValidSeverity()
+    {
+        testcase("Valid severity");
+        using namespace test::jtx;
+        Env env{*this};
+
+        // Every alias Logs::fromString accepts, paired with the name
+        // Logs::toString reports it back as. Matching is case insensitive.
+        std::array<std::pair<char const*, char const*>, 12> const goodSeverities{{
+            {"trace", "Trace"},
+            {"debug", "Debug"},
+            {"info", "Info"},
+            {"information", "Info"},
+            {"warn", "Warning"},
+            {"warning", "Warning"},
+            {"warnings", "Warning"},
+            {"error", "Error"},
+            {"errors", "Error"},
+            {"fatal", "Fatal"},
+            {"fatals", "Fatal"},
+            {"FaTaL", "Fatal"},
+        }};
+
+        // Apply the aliases to a partition of this suite's own rather than to
+        // the base threshold: nothing writes to it, so walking down to Trace
+        // does not flood the test output the way lowering the base would.
+        std::string const name{kTestPartition};
+
+        for (auto const& [severity, reported] : goodSeverities)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::severity] = severity;
+            params[jss::partition] = name;
+            auto const result = env.client().invoke("log_level", params)[jss::result];
+            BEAST_EXPECTS(!result.isMember(jss::error), severity);
+            BEAST_EXPECTS(result[jss::status] == "success", severity);
+            BEAST_EXPECTS(levels(env)[name] == reported, severity);
+        }
+
+        // With no partition given, the severity applies to the base threshold,
+        // which the listing reports under "base".
+        json::Value params{json::ValueType::Object};
+        params[jss::severity] = "fatals";
+        auto const result = env.client().invoke("log_level", params)[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(levels(env)[jss::base] == "Fatal");
+    }
+
+    void
+    testValidPartition()
+    {
+        testcase("Valid partition");
+        using namespace test::jtx;
+        Env env{*this};
+
+        std::string const name{kTestPartition};
+
+        // A partition is created on demand, so naming one that does not exist
+        // yet is legitimate, and it shows up in the listing at the level given.
+        json::Value params{json::ValueType::Object};
+        params[jss::severity] = "fatal";
+        params[jss::partition] = name;
+        auto const result = env.client().invoke("log_level", params)[jss::result];
+        BEAST_EXPECT(!result.isMember(jss::error));
+        BEAST_EXPECT(result[jss::status] == "success");
+        BEAST_EXPECT(levels(env)[name] == "Fatal");
+
+        // "base" is matched case insensitively and sets the base threshold. It
+        // must not create a partition of that name, so a mixed-case spelling is
+        // what tells the two apart.
+        params[jss::severity] = "error";
+        params[jss::partition] = "BASE";
+        auto const baseResult = env.client().invoke("log_level", params)[jss::result];
+        BEAST_EXPECT(!baseResult.isMember(jss::error));
+        BEAST_EXPECT(baseResult[jss::status] == "success");
+
+        auto const current = levels(env);
+        BEAST_EXPECT(current[jss::base] == "Error");
+        BEAST_EXPECT(!current.isMember("BASE"));
+
+        // Setting the base threshold is not additive: Logs::threshold assigns
+        // it to every existing sink, so the partition set above is reset too.
+        BEAST_EXPECT(current[name] == "Error");
+    }
+
+    void
+    testBadSeverity()
+    {
+        testcase("Invalid severity");
+        using namespace test::jtx;
+        Env env{*this};
+
+        auto bad = badValues();
+        bad.push_back(json::Value{"err"});  // a string, but not a severity
+
+        for (auto const& badSeverity : bad)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::severity] = badSeverity;
+            auto const result = env.client().invoke("log_level", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+        }
+
+        // A rejected severity must not have moved the base threshold off the
+        // level Env starts at.
+        BEAST_EXPECT(levels(env)[jss::base] == "Error");
+    }
+
+    void
+    testBadPartition()
+    {
+        testcase("Invalid partition");
+        using namespace test::jtx;
+        Env env{*this};
+
+        auto bad = badValues();
+        // Logs::get creates the partition, so an empty name is as damaging as a
+        // coerced one: it wedges a nameless sink into the listing forever.
+        bad.push_back(json::Value{""});
+
+        for (auto const& badPartition : bad)
+        {
+            json::Value params{json::ValueType::Object};
+            params[jss::severity] = "warn";
+            params[jss::partition] = badPartition;
+            auto const result = env.client().invoke("log_level", params)[jss::result];
+            BEAST_EXPECT(result[jss::error] == "invalidParams");
+            BEAST_EXPECT(result[jss::status] == "error");
+        }
+
+        // The point of the type check: none of the rejected values may have
+        // been stringified into a partition name. Other partitions can appear
+        // on their own as the server logs, so look for these names rather than
+        // comparing the whole listing.
+        auto const current = levels(env);
+        for (auto const* junk : kJunkPartitions)
+            BEAST_EXPECTS(!current.isMember(junk), std::string{"partition '"} + junk + "'");
+
+        // A rejected partition must not have moved the base threshold either.
+        BEAST_EXPECT(current[jss::base] == "Error");
+    }
+
+public:
+    void
+    run() override
+    {
+        testGetLevels();
+        testValidSeverity();
+        testValidPartition();
+        testBadSeverity();
+        testBadPartition();
+    }
+};
+
+BEAST_DEFINE_TESTSUITE(LogLevel, rpc, xrpl);
+
+}  // namespace xrpl

--- a/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
+++ b/src/xrpld/rpc/handlers/admin/log/LogLevel.cpp
@@ -35,7 +35,15 @@ doLogLevel(RPC::JsonContext& context)
         return ret;
     }
 
-    auto const severity = Logs::fromString(context.params[jss::severity].asString());
+    // Guard the conversion: json::Value::asString() throws for arrays and objects,
+    // which would surface as a generic internal error instead of invalid parameters,
+    // and silently stringifies scalars, so a number or a bool would be matched
+    // against the severity names as its printed form.
+    auto const& jvSeverity = context.params[jss::severity];
+    if (!jvSeverity.isString())
+        return rpcError(RpcInvalidParams);
+
+    auto const severity = Logs::fromString(jvSeverity.asString());
 
     if (not severity.has_value())
         return rpcError(RpcInvalidParams);
@@ -49,24 +57,26 @@ doLogLevel(RPC::JsonContext& context)
     }
 
     // log_level partition severity base?
-    if (context.params.isMember(jss::partition))
+    // Guard the conversion for the same reason, and reject the empty name: Logs::get
+    // creates a partition on demand, so any value that is not a real partition name
+    // adds a junk sink that this command then reports forever.
+    auto const& jvPartition = context.params[jss::partition];
+    if (!jvPartition.isString() || jvPartition.asString().empty())
+        return rpcError(RpcInvalidParams);
+
+    // set partition threshold
+    std::string const partition(jvPartition.asString());
+
+    if (boost::iequals(partition, "base"))
     {
-        // set partition threshold
-        std::string const partition(context.params[jss::partition].asString());
-
-        if (boost::iequals(partition, "base"))
-        {
-            context.app.getLogs().threshold(*severity);
-        }
-        else
-        {
-            context.app.getLogs().get(partition).threshold(*severity);
-        }
-
-        return json::ValueType::Object;
+        context.app.getLogs().threshold(*severity);
+    }
+    else
+    {
+        context.app.getLogs().get(partition).threshold(*severity);
     }
 
-    return rpcError(RpcInvalidParams);
+    return json::ValueType::Object;
 }
 
 }  // namespace xrpl


### PR DESCRIPTION
doLogLevel read both parameters with an unguarded asString(), which throws for arrays and objects and silently stringifies every scalar. The throw was swallowed by callMethod's catch-all, so a malformed value produced a generic internal error rather than invalidParams, and the request was recorded as a server fault in the perf log.

The severity path was only half broken: a coerced scalar still failed Logs::fromString and came back as invalidParams, so just arrays and objects misbehaved. The partition path had no downstream validation at all, and Logs::get creates a sink on demand, so a coerced value permanently added a partition named "42", "true" or "" to the map that log_level itself then reported on every subsequent call.

Guard both conversions with an isString() check and return invalidParams when it fails. Reject the empty partition name for the same reason the type check exists: it is not a partition anyone can have meant, and accepting it wedges a nameless sink into the listing forever.

This makes the handler stricter: a severity or partition given as a number, a bool, or null was previously coerced and is now rejected. The commandline builds both fields from argv via asString(), so they are always strings there and the parser is unaffected.

Also drop the second isMember(partition) test, which was unconditionally true because the preceding branch already returned, along with the unreachable return it guarded. No behavior change.

Add a LogLevel test suite, which did not exist; the RPCCall cases cover only the commandline-to-JSON parse and never reach the handler.

<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
