### PR TITLE
Skip oversized tmmanifests

### DIFF
--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1225,7 +1225,20 @@ OverlayImpl::getManifestsMessage()
         manifestMessage_.reset();
 
         if (tm.list_size() != 0)
-            manifestMessage_ = std::make_shared<Message>(tm, protocol::mtMANIFESTS);
+        {
+            auto const messageSize = Message::totalSize(tm);
+            if (messageSize <= kMaximumMessageSize)
+            {
+                manifestMessage_ = std::make_shared<Message>(tm, protocol::mtMANIFESTS);
+            }
+            else
+            {
+                JLOG(journal_.warn())
+                    << "Skipping oversized TMManifests broadcast: manifests=" << tm.list_size()
+                    << " bytes=" << messageSize
+                    << " max_bytes=" << kMaximumMessageSize;
+            }
+        }
 
         manifestListSeq_ = seq;
     }

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1224,23 +1224,23 @@ OverlayImpl::getManifestsMessage()
 
         manifestMessage_.reset();
 
-        if (tm.list_size() != 0)
-        {
-            auto const messageSize = Message::totalSize(tm);
-            if (messageSize <= kMaximumMessageSize)
-            {
-                manifestMessage_ = std::make_shared<Message>(tm, protocol::mtMANIFESTS);
-            }
-            else
-            {
-                JLOG(journal_.warn())
-                    << "Skipping oversized TMManifests broadcast: manifests=" << tm.list_size()
-                    << " bytes=" << messageSize
-                    << " max_bytes=" << kMaximumMessageSize;
-            }
-        }
+if (tm.list_size() != 0)
+{
+    auto const messageSize = Message::totalSize(tm);
+    if (messageSize <= kMaximumMessageSize)
+    {
+        manifestMessage_ = std::make_shared<Message>(tm, protocol::mtMANIFESTS);
+    }
+    else
+    {
+        JLOG(journal_.warn())
+            << "Skipping oversized TMManifests broadcast: manifests=" << tm.list_size()
+            << " bytes=" << messageSize
+            << " max_bytes=" << kMaximumMessageSize;
+    }
+}
 
-        manifestListSeq_ = seq;
+manifestListSeq_ = seq;
     }
 
     return manifestMessage_;

--- a/src/xrpld/overlay/detail/OverlayImpl.cpp
+++ b/src/xrpld/overlay/detail/OverlayImpl.cpp
@@ -1222,25 +1222,25 @@ OverlayImpl::getManifestsMessage()
                 hr.addSuppression(manifest.hash());
             });
 
-        manifestMessage_.reset();
+            manifestMessage_.reset();
 
-if (tm.list_size() != 0)
-{
-    auto const messageSize = Message::totalSize(tm);
-    if (messageSize <= kMaximumMessageSize)
+    if (tm.list_size() != 0)
     {
-        manifestMessage_ = std::make_shared<Message>(tm, protocol::mtMANIFESTS);
+        auto const messageSize = Message::totalSize(tm);
+        if (messageSize <= kMaximumMessageSize)
+        {
+            manifestMessage_ = std::make_shared<Message>(tm, protocol::mtMANIFESTS);
+        }
+        else
+        {
+            JLOG(journal_.warn())
+                << "Skipping oversized TMManifests broadcast: manifests=" << tm.list_size()
+                << " bytes=" << messageSize
+                << " max_bytes=" << kMaximumMessageSize;
+        }
     }
-    else
-    {
-        JLOG(journal_.warn())
-            << "Skipping oversized TMManifests broadcast: manifests=" << tm.list_size()
-            << " bytes=" << messageSize
-            << " max_bytes=" << kMaximumMessageSize;
-    }
-}
 
-manifestListSeq_ = seq;
+    manifestListSeq_ = seq;
     }
 
     return manifestMessage_;


### PR DESCRIPTION
## Summary

This PR prevents oversized aggregate `TMManifests` messages from being framed and sent on the overlay.

`TMManifests` is currently cached as a single aggregate message in `OverlayImpl::getManifestsMessage()`. If the serialized aggregate exceeds `kMaximumMessageSize`, peers will reject it on receipt. This change checks `Message::totalSize(tm)` before constructing the overlay `Message`; oversized aggregates are skipped with a warning instead of being queued for send.

## Rationale

The receive path already enforces `kMaximumMessageSize` for overlay messages. This adds the matching sender-side guard for the aggregate manifest broadcast path.

This is intentionally conservative:

- No wire protocol changes.
- No receive-path changes.
- No message type changes.
- Under-limit `TMManifests` broadcasts continue unchanged.
- Oversized aggregate broadcasts are not sent as unusable frames.

A future follow-up could split `TMManifests` into bounded chunks. This PR only prevents sending aggregate manifest messages that exceed the existing overlay message limit.

## Testing

Not run locally.