### PR TITLE
fix: Watch nix/*.nix files for direnv cache invalidation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,3 @@
+watch_file nix/*.nix
+
 use flake


### PR DESCRIPTION
## Problem

nix-direnv's use flake only watches flake.nix, flake.lock, and devshell.toml for cache invalidation — that list is hardcoded in nix-direnv itself. Our actual devshell logic lives in nix/devshell.nix (imported by flake.nix, which in turn pulls in nix/packages.nix and nix/compilers.nix), and none of those files are on nix-direnv's watch list.

Concretely: nix/devshell.nix recently started exporting the XRPL/XrplSanity.cmake toolchain guard var, but since flake.nix itself wasn't touched, direnv's cache check never noticed the change. Anyone with a pre-existing cached shell kept getting served the old derivation — same compiler, same PATH, indistinguishable at a glance. Result: cmake configure fails with A Nix compiler is being used outside the xrpld dev shell even though you're genuinely inside the dev shell.

Verified directly: the cached .direnv/flake-profile-*.rc had no XRPL_DEVSHELL set, and nix show-derivation on the cached .drv confirmed the var was simply absent from the built env — nothing wrong locally, just a stale cache.

This will keep recurring on every future edit to nix/devshell.nix, nix/packages.nix, or nix/compilers.nix (new package, toolchain bump, another env var), since none of those are in nix-direnv's watch list.

## Fix

Add watch_file nix/*.nix to .envrc before use flake, so direnv explicitly re-evaluates the flake whenever any of the nix/*.nix files change, regardless of whether flake.nix itself was edited.