### PR TITLE
docs: Add a fix for `command not found: nix` on macOS

### DIFF
--- a/docs/build/nix_troubleshooting.md
+++ b/docs/build/nix_troubleshooting.md
@@ -44,11 +44,6 @@ diff /etc/zshrc /etc/zshrc.backup-before-nix
 If they are identical, the Nix snippet was wiped. This is upstream issue
 [NixOS/nix#3616](https://github.com/NixOS/nix/issues/3616).
 
-For fish, note that `$__fish_sysconf_dir` depends on how fish was installed —
-with Homebrew on Apple Silicon it is `/opt/homebrew/etc/fish`, so the file is
-`/opt/homebrew/etc/fish/conf.d/nix.fish`. fish sources everything in `conf.d`
-automatically, so nothing in your own config ever mentions Nix.
-
 ### Fix
 
 To unblock the current shell:

--- a/docs/build/nix_troubleshooting.md
+++ b/docs/build/nix_troubleshooting.md
@@ -3,6 +3,83 @@
 Common issues encountered when using the [Nix development shell](./nix.md), and
 how to resolve them.
 
+## `command not found: nix` after a macOS update
+
+If a shell suddenly can't find `nix` at all:
+
+```
+$ nix develop
+zsh: command not found: nix
+```
+
+then Nix is almost certainly still installed — only the shell hook that puts it
+on your `PATH` is gone. Confirm that first:
+
+```bash
+ls -l /nix/var/nix/profiles/default/bin/nix
+```
+
+If that exists, the installation is fine and this is purely a `PATH` problem.
+
+### Why it happens
+
+The installer does not touch your dotfiles. Instead it sources a setup script
+from the Nix store by editing **system-wide** rc files:
+
+| Shell | File the installer edits              |
+| ----- | ------------------------------------- |
+| bash  | `/etc/bashrc`, `/etc/bash.bashrc`     |
+| zsh   | `/etc/zshrc`                          |
+| fish  | `$__fish_sysconf_dir/conf.d/nix.fish` |
+
+macOS manages `/etc/zshrc`, so an OS update can replace it with the vendor copy
+and silently drop the Nix block. `/etc/bashrc` and the fish file usually survive,
+which is why the breakage often shows up in zsh only. You can verify this by
+diffing against the backup the installer left behind:
+
+```bash
+diff /etc/zshrc /etc/zshrc.backup-before-nix
+```
+
+If they are identical, the Nix snippet was wiped. This is upstream issue
+[NixOS/nix#3616](https://github.com/NixOS/nix/issues/3616).
+
+For fish, note that `$__fish_sysconf_dir` depends on how fish was installed —
+with Homebrew on Apple Silicon it is `/opt/homebrew/etc/fish`, so the file is
+`/opt/homebrew/etc/fish/conf.d/nix.fish`. fish sources everything in `conf.d`
+automatically, so nothing in your own config ever mentions Nix.
+
+### Fix
+
+To unblock the current shell:
+
+```bash
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+```
+
+For a permanent fix, add the snippet to your **user** rc file rather than
+restoring `/etc/zshrc` — user dotfiles are not clobbered by OS updates:
+
+```bash
+cat >>~/.zshrc <<'EOF'
+
+# Nix
+if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
+  . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
+fi
+# End Nix
+EOF
+```
+
+The scripts guard against double-sourcing via `__ETC_PROFILE_NIX_SOURCED`, so
+this is safe even if a system-wide hook is later restored.
+
+> [!NOTE]
+> `/etc/zshrc` and `~/.zshrc` are only read by **interactive** zsh. If the
+> snippet is present but `zsh -c '…'`, a script, or an IDE terminal still can't
+> find `nix`, that shell is non-interactive — put the snippet in `~/.zshenv`
+> instead.
+
 ## Git worktrees
 
 If `nix develop` fails with an error like:


### PR DESCRIPTION
<!--
This PR template helps you write a good pull request description.
Please feel free to include additional useful information even beyond what is requested below.

If your branch is on a personal fork and has a name that allows it to
run CI build/test jobs (e.g. "ci/foo"), remember to rename it BEFORE
opening the PR. This avoids redundant test runs. Renaming
the branch after opening the PR will close the PR.
https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-branches-in-your-repository/renaming-a-branch
-->

## High Level Overview of Change

This documents a problem with nix missing after macOS update.

<!--
Please include a summary of the changes.
This may be a direct input to the release notes.
If too broad, please consider splitting into multiple PRs.
If there is a relevant task or issue, please link it here.
-->

### Context of Change

<!--
Please include the context of a change.
If a bug fix, when was the bug introduced? What was the behavior?
If a new feature, why was this architecture chosen? What were the alternatives?
If a refactor, how is this better than the previous implementation?

If there is a spec or design document for this feature, please link it here.
-->

### API Impact

<!--
Please check [x] relevant options, delete irrelevant ones.

* If there is any impact to the public API methods (HTTP / WebSocket), please update https://github.com/xrplf/rippled/blob/develop/API-CHANGELOG.md
  * Update API-CHANGELOG.md and add the change directly in this PR by pushing to your PR branch.
* libxrpl: See https://github.com/XRPLF/rippled/blob/develop/docs/build/depend.md
* Peer Protocol: See https://xrpl.org/peer-protocol.html
-->

- [ ] Public API: New feature (new methods and/or new fields)
- [ ] Public API: Breaking change (in general, breaking changes should only impact the next api_version)
- [ ] `libxrpl` change (any change that may affect `libxrpl` or dependents of `libxrpl`)
- [ ] Peer protocol change (must be backward compatible or bump the peer protocol version)

<!--
## Before / After
If relevant, use this section for an English description of the change at a technical level.
If this change affects an API, examples should be included here.

For performance-impacting changes, please provide these details:
1. Is this a new feature, bug fix, or improvement to existing functionality?
2. What behavior/functionality does the change impact?
3. In what processing can the impact be measured? Be as specific as possible - e.g. RPC client call, payment transaction that involves LOB, AMM, caching, DB operations, etc.
4. Does this change affect concurrent processing - e.g. does it involve acquiring locks, multi-threaded processing, or async processing?
-->

<!--
## Test Plan
If helpful, please describe the tests that you ran to verify your changes and provide instructions so that others can reproduce.
This section may not be needed if your change includes thoroughly commented unit tests.
-->

<!--
## Future Tasks
For future tasks related to this PR.
-->
